### PR TITLE
feat: MyBatis와 MySQL 기본 연결 추가

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SystemMapper.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SystemMapper.java
@@ -1,0 +1,8 @@
+package com.ticketrush.centralserver.infrastructure.persistence.mapper;
+
+import org.apache.ibatis.annotations.Mapper;
+
+@Mapper
+public interface SystemMapper {
+	Integer selectOne();
+}

--- a/central-server/src/main/resources/application-local.yml
+++ b/central-server/src/main/resources/application-local.yml
@@ -1,9 +1,10 @@
 spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
   jackson:
     time-zone: Asia/Seoul
+  datasource:
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:13306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:rootpassword}
 
 server:
   port: ${SERVER_PORT:18080}

--- a/central-server/src/main/resources/application.yml
+++ b/central-server/src/main/resources/application.yml
@@ -4,6 +4,9 @@ spring:
   profiles:
     default: local
 
+mybatis:
+  mapper-locations: classpath:/mapper/**/*.xml
+
 management:
   endpoints:
     web:

--- a/central-server/src/main/resources/mapper/SystemMapper.xml
+++ b/central-server/src/main/resources/mapper/SystemMapper.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ticketrush.centralserver.infrastructure.persistence.mapper.SystemMapper">
+
+    <select id="selectOne" resultType="java.lang.Integer">
+        SELECT 1
+        FROM DUAL
+    </select>
+
+</mapper>

--- a/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
@@ -1,15 +1,19 @@
 package com.ticketrush.centralserver;
 
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.springframework.test.context.ActiveProfiles;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
-@SpringBootTest
+@SpringBootTest(
+	properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration"
+)
 @ActiveProfiles("test")
 class CentralServerApplicationTests {
 
 	@Test
-	void contextLoads() {
+	@DisplayName("애플리케이션 컨텍스트가 정상적으로 로드된다")
+	void 애플리케이션_컨텍스트가_정상적으로_로드된다() {
 	}
 
 }

--- a/central-server/src/test/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SystemMapperTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SystemMapperTest.java
@@ -1,0 +1,31 @@
+package com.ticketrush.centralserver.infrastructure.persistence.mapper;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mybatis.spring.boot.test.autoconfigure.MybatisTest;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.test.context.ActiveProfiles;
+
+@MybatisTest
+@ActiveProfiles("test")
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class SystemMapperTest {
+
+	private final SystemMapper systemMapper;
+
+	@Autowired
+	SystemMapperTest(SystemMapper systemMapper) {
+		this.systemMapper = systemMapper;
+	}
+
+	@Test
+	@DisplayName("MyBatis로 MySQL에 기본 조회를 수행할 수 있다")
+	void MyBatis로_MySQL에_기본_조회를_수행할_수_있다() {
+		Integer result = systemMapper.selectOne();
+
+		assertThat(result).isEqualTo(1);
+	}
+}

--- a/central-server/src/test/resources/application-test.yml
+++ b/central-server/src/test/resources/application-test.yml
@@ -1,6 +1,7 @@
 spring:
-  autoconfigure:
-    exclude:
-      - org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration
   jackson:
     time-zone: Asia/Seoul
+  datasource:
+    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:13306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+    username: ${DB_USERNAME:root}
+    password: ${DB_PASSWORD:rootpassword}


### PR DESCRIPTION
## 작업 내용
- local/test DataSource 설정 추가
- MyBatis mapper XML 경로 설정
- 기본 조회용 mapper와 XML 추가
- 스모크 테스트와 DB 연결 테스트 역할 분리

## 확인한 것
- `./gradlew test` 통과
- MyBatis 기본 조회 동작 확인

Close #8 
