### PR TITLE
feat: 공연 조회 API 초안 추가

### DIFF
--- a/central-server/build.gradle
+++ b/central-server/build.gradle
@@ -28,6 +28,11 @@ dependencies {
 	testImplementation 'org.mybatis.spring.boot:mybatis-spring-boot-starter-test:3.0.5'
 	testImplementation 'com.tngtech.archunit:archunit-junit5:1.4.1'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+	compileOnly 'org.projectlombok:lombok'
+	annotationProcessor 'org.projectlombok:lombok'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
 }
 
 tasks.named('test') {

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
@@ -1,0 +1,29 @@
+package com.ticketrush.centralserver.application.performance;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.PerformanceQueryMapper;
+import com.ticketrush.centralserver.interfaces.api.performance.dto.PerformanceResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class PerformanceQueryService {
+
+	private final PerformanceQueryMapper performanceQueryMapper;
+
+	public List<PerformanceResponse> getPerformances() {
+		return performanceQueryMapper.findAll().stream()
+			.map(row -> new PerformanceResponse(
+				row.id(),
+				row.title(),
+				row.venue(),
+				row.totalSeats()
+			))
+			.toList();
+	}
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/PerformanceQueryMapper.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/PerformanceQueryMapper.java
@@ -1,0 +1,14 @@
+package com.ticketrush.centralserver.infrastructure.persistence.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+
+import com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow;
+
+@Mapper
+public interface PerformanceQueryMapper {
+
+	List<PerformanceRow> findAll();
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/model/PerformanceRow.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/model/PerformanceRow.java
@@ -1,0 +1,9 @@
+package com.ticketrush.centralserver.infrastructure.persistence.model;
+
+public record PerformanceRow(
+	Long id,
+	String title,
+	String venue,
+	Integer totalSeats
+) {
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceController.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceController.java
@@ -1,0 +1,26 @@
+package com.ticketrush.centralserver.interfaces.api.performance;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ticketrush.centralserver.application.performance.PerformanceQueryService;
+import com.ticketrush.centralserver.interfaces.api.performance.dto.PerformanceResponse;
+import com.ticketrush.centralserver.support.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/performances")
+@RequiredArgsConstructor
+public class PerformanceController {
+
+	private final PerformanceQueryService performanceQueryService;
+
+	@GetMapping
+	public ApiResponse<List<PerformanceResponse>> getPerformances() {
+		return ApiResponse.success(performanceQueryService.getPerformances());
+	}
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/performance/dto/PerformanceResponse.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/performance/dto/PerformanceResponse.java
@@ -1,0 +1,9 @@
+package com.ticketrush.centralserver.interfaces.api.performance.dto;
+
+public record PerformanceResponse(
+	Long id,
+	String title,
+	String venue,
+	Integer totalSeats
+) {
+}

--- a/central-server/src/main/resources/application.yml
+++ b/central-server/src/main/resources/application.yml
@@ -6,6 +6,8 @@ spring:
 
 mybatis:
   mapper-locations: classpath:/mapper/**/*.xml
+  configuration:
+    map-underscore-to-camel-case: true
 
 management:
   endpoints:

--- a/central-server/src/main/resources/mapper/performance/PerformanceQueryMapper.xml
+++ b/central-server/src/main/resources/mapper/performance/PerformanceQueryMapper.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ticketrush.centralserver.infrastructure.persistence.mapper.PerformanceQueryMapper">
+
+    <select id="findAll" resultType="com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow">
+        SELECT
+            id,
+            title,
+            venue,
+            total_seats
+        FROM performance
+        ORDER BY id DESC
+    </select>
+
+</mapper>

--- a/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
@@ -4,12 +4,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import com.ticketrush.centralserver.application.performance.PerformanceQueryService;
 
 @SpringBootTest(
 	properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration"
 )
 @ActiveProfiles("test")
 class CentralServerApplicationTests {
+
+	@MockitoBean
+	private PerformanceQueryService performanceQueryService;
 
 	@Test
 	@DisplayName("애플리케이션 컨텍스트가 정상적으로 로드된다")

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceControllerTest.java
@@ -1,0 +1,41 @@
+package com.ticketrush.centralserver.interfaces.api.performance;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql(statements = {
+	"DELETE FROM performance",
+	"INSERT INTO performance (title, description, venue, total_seats) VALUES ('테스트 공연', '설명', '올림픽홀', 500)",
+	"INSERT INTO performance (title, description, venue, total_seats) VALUES ('두번째 공연', '설명', '체조경기장', 1000)"
+})
+class PerformanceControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("공연 목록 조회 API가 정상 응답한다")
+	void 공연_목록_조회_API가_정상_응답한다() throws Exception {
+		mockMvc.perform(get("/api/v1/performances"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].title").value("두번째 공연"))
+			.andExpect(jsonPath("$.data[0].venue").value("체조경기장"))
+			.andExpect(jsonPath("$.data[0].totalSeats").value(1000))
+			.andExpect(jsonPath("$.data[1].title").value("테스트 공연"));
+	}
+
+
+}


### PR DESCRIPTION
## 작업 내용
- 공연 목록 조회용 mapper와 조회 모델 추가
- 공연 조회 서비스와 API 엔드포인트 추가
- Lombok 설정 추가
- 공연 조회 API 통합 테스트 추가

## 확인한 것
- `GET /api/v1/performances` 응답 확인
- MyBatis 조회 결과가 API 응답 DTO로 변환되는 흐름 확인
- `./gradlew test --rerun-tasks` 통과

Close #10 