### PR TITLE
feat: 공연 단건 조회 API 추가

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
@@ -5,7 +5,10 @@ import java.util.List;
 import org.springframework.stereotype.Service;
 
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.PerformanceQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow;
 import com.ticketrush.centralserver.interfaces.api.performance.dto.PerformanceResponse;
+import com.ticketrush.centralserver.support.exception.ApiException;
+import com.ticketrush.centralserver.support.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,13 +20,25 @@ public class PerformanceQueryService {
 
 	public List<PerformanceResponse> getPerformances() {
 		return performanceQueryMapper.findAll().stream()
-			.map(row -> new PerformanceResponse(
-				row.id(),
-				row.title(),
-				row.venue(),
-				row.totalSeats()
-			))
+			.map(this::toResponse)
 			.toList();
 	}
+
+	public PerformanceResponse getPerformance(Long performanceId) {
+		return performanceQueryMapper.findById(performanceId)
+			.map(this::toResponse)
+			.orElseThrow(() -> new ApiException(ErrorCode.PERFORMANCE_NOT_FOUND));
+	}
+
+	private PerformanceResponse toResponse(PerformanceRow row) {
+		return new PerformanceResponse(
+			row.id(),
+			row.title(),
+			row.venue(),
+			row.totalSeats()
+		);
+	}
+
+
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/PerformanceQueryMapper.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/PerformanceQueryMapper.java
@@ -1,6 +1,7 @@
 package com.ticketrush.centralserver.infrastructure.persistence.mapper;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 
@@ -10,5 +11,7 @@ import com.ticketrush.centralserver.infrastructure.persistence.model.Performance
 public interface PerformanceQueryMapper {
 
 	List<PerformanceRow> findAll();
+
+	Optional<PerformanceRow> findById(Long performanceId);
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceController.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceController.java
@@ -3,6 +3,7 @@ package com.ticketrush.centralserver.interfaces.api.performance;
 import java.util.List;
 
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -23,4 +24,10 @@ public class PerformanceController {
 	public ApiResponse<List<PerformanceResponse>> getPerformances() {
 		return ApiResponse.success(performanceQueryService.getPerformances());
 	}
+
+	@GetMapping("/{performanceId}")
+	public ApiResponse<PerformanceResponse> getPerformance(@PathVariable Long performanceId) {
+		return ApiResponse.success(performanceQueryService.getPerformance(performanceId));
+	}
+
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/support/exception/ErrorCode.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/support/exception/ErrorCode.java
@@ -4,7 +4,10 @@ import org.springframework.http.HttpStatus;
 
 public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_INTERNAL_ERROR", "서버 내부 오류가 발생했습니다."),
-	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "잘못된 요청입니다.");
+	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "잘못된 요청입니다."),
+	PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_NOT_FOUND", "공연을 찾을 수 없습니다."),
+
+	;
 
 	private final HttpStatus status;
 	private final String code;

--- a/central-server/src/main/resources/mapper/SystemMapper.xml
+++ b/central-server/src/main/resources/mapper/SystemMapper.xml
@@ -9,4 +9,14 @@
         FROM DUAL
     </select>
 
+    <select id="findById" resultType="com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow">
+        SELECT
+        id,
+        title,
+        venue,
+        total_seats
+        FROM performance
+        WHERE id = #{performanceId}
+    </select>
+
 </mapper>

--- a/central-server/src/main/resources/mapper/SystemMapper.xml
+++ b/central-server/src/main/resources/mapper/SystemMapper.xml
@@ -9,14 +9,4 @@
         FROM DUAL
     </select>
 
-    <select id="findById" resultType="com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow">
-        SELECT
-        id,
-        title,
-        venue,
-        total_seats
-        FROM performance
-        WHERE id = #{performanceId}
-    </select>
-
 </mapper>

--- a/central-server/src/main/resources/mapper/performance/PerformanceQueryMapper.xml
+++ b/central-server/src/main/resources/mapper/performance/PerformanceQueryMapper.xml
@@ -14,4 +14,14 @@
         ORDER BY id DESC
     </select>
 
+    <select id="findById" resultType="com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow">
+        SELECT
+        id,
+        title,
+        venue,
+        total_seats
+        FROM performance
+        WHERE id = #{performanceId}
+    </select>
+
 </mapper>

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceControllerTest.java
@@ -17,6 +17,7 @@ import org.springframework.test.web.servlet.MockMvc;
 @ActiveProfiles("test")
 @Sql(statements = {
 	"DELETE FROM performance",
+	"ALTER TABLE performance AUTO_INCREMENT = 1",
 	"INSERT INTO performance (title, description, venue, total_seats) VALUES ('테스트 공연', '설명', '올림픽홀', 500)",
 	"INSERT INTO performance (title, description, venue, total_seats) VALUES ('두번째 공연', '설명', '체조경기장', 1000)"
 })
@@ -36,6 +37,29 @@ class PerformanceControllerTest {
 			.andExpect(jsonPath("$.data[0].totalSeats").value(1000))
 			.andExpect(jsonPath("$.data[1].title").value("테스트 공연"));
 	}
+
+	@Test
+	@DisplayName("공연 단건 조회 API가 정상 응답한다")
+	void 공연_단건_조회_API가_정상_응답한다() throws Exception {
+		mockMvc.perform(get("/api/v1/performances/{performanceId}", 1L))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.id").value(1))
+			.andExpect(jsonPath("$.data.title").value("테스트 공연"))
+			.andExpect(jsonPath("$.data.venue").value("올림픽홀"))
+			.andExpect(jsonPath("$.data.totalSeats").value(500));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 공연 조회 시 404 에러 응답을 반환한다")
+	void 존재하지_않는_공연_조회_시_404_에러_응답을_반환한다() throws Exception {
+		mockMvc.perform(get("/api/v1/performances/{performanceId}", 9999L))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("PERFORMANCE_NOT_FOUND"))
+			.andExpect(jsonPath("$.error.message").value("공연을 찾을 수 없습니다."));
+	}
+
 
 
 }


### PR DESCRIPTION
## 작업 내용
- 공연 ID 기반 단건 조회 mapper 추가
- 공연 단건 조회 서비스와 API 엔드포인트 추가
- 존재하지 않는 공연 조회 시 공통 에러 응답 처리
- 공연 단건 조회 API 테스트 추가

## 확인한 것
- `GET /api/v1/performances/{performanceId}` 정상 응답 확인
- 없는 공연 ID 조회 시 `404` 에러 응답 확인
- `./gradlew test --rerun-tasks` 통과

Close #12 