### PR TITLE
feat: 회차별 좌석 조회 API 추가

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatQueryService.java
@@ -1,0 +1,35 @@
+package com.ticketrush.centralserver.application.seat;
+
+import java.util.List;
+
+import org.springframework.stereotype.Service;
+
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
+import com.ticketrush.centralserver.interfaces.api.schedule.dto.SeatResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class SeatQueryService {
+
+	private final SeatQueryMapper seatQueryMapper;
+
+	public List<SeatResponse> getSeats(Long scheduleId, String status) {
+		return seatQueryMapper.findByScheduleIdAndStatus(scheduleId, status).stream()
+			.map(this::toResponse)
+			.toList();
+	}
+
+	private SeatResponse toResponse(SeatRow row) {
+		return new SeatResponse(
+			row.id(),
+			row.scheduleId(),
+			row.seatNumber(),
+			row.status(),
+			row.price()
+		);
+	}
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
@@ -1,0 +1,15 @@
+package com.ticketrush.centralserver.infrastructure.persistence.mapper;
+
+import java.util.List;
+
+import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
+
+import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
+
+@Mapper
+public interface SeatQueryMapper {
+
+	List<SeatRow> findByScheduleIdAndStatus(@Param("scheduleId") Long scheduleId, @Param("status") String status);
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/model/SeatRow.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/model/SeatRow.java
@@ -1,0 +1,10 @@
+package com.ticketrush.centralserver.infrastructure.persistence.model;
+
+public record SeatRow(
+	Long id,
+	Long scheduleId,
+	String seatNumber,
+	String status,
+	Integer price
+) {
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/schedule/ScheduleController.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/schedule/ScheduleController.java
@@ -1,0 +1,30 @@
+package com.ticketrush.centralserver.interfaces.api.schedule;
+
+import java.util.List;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ticketrush.centralserver.application.seat.SeatQueryService;
+import com.ticketrush.centralserver.interfaces.api.schedule.dto.SeatResponse;
+import com.ticketrush.centralserver.support.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/schedules")
+@RequiredArgsConstructor
+public class ScheduleController {
+
+	private final SeatQueryService seatQueryService;
+
+	@GetMapping("/{scheduleId}/seats")
+	public ApiResponse<List<SeatResponse>> getSeats(@PathVariable Long scheduleId, @RequestParam(required = false) String status) {
+		return ApiResponse.success(seatQueryService.getSeats(scheduleId, status));
+	}
+
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/schedule/dto/SeatResponse.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/schedule/dto/SeatResponse.java
@@ -1,0 +1,10 @@
+package com.ticketrush.centralserver.interfaces.api.schedule.dto;
+
+public record SeatResponse(
+	Long id,
+	Long scheduleId,
+	String seatNumber,
+	String status,
+	Integer price
+) {
+}

--- a/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
+++ b/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<!DOCTYPE mapper
+        PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
+        "https://mybatis.org/dtd/mybatis-3-mapper.dtd">
+<mapper namespace="com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper">
+
+    <select id="findByScheduleIdAndStatus" resultType="com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow">
+        SELECT
+            id,
+            schedule_id,
+            seat_number,
+            status,
+            price
+        FROM seat
+        WHERE schedule_id = #{scheduleId}
+        <if test="status != null and status != ''">
+            AND status = #{status}
+        </if>
+        ORDER BY seat_number ASC, id ASC
+    </select>
+
+</mapper>

--- a/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.ticketrush.centralserver.application.performance.PerformanceQueryService;
 import com.ticketrush.centralserver.application.schedule.ScheduleQueryService;
+import com.ticketrush.centralserver.application.seat.SeatQueryService;
 
 @SpringBootTest(
 	properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration"
@@ -20,6 +21,9 @@ class CentralServerApplicationTests {
 
 	@MockitoBean
 	private ScheduleQueryService scheduleQueryService;
+
+	@MockitoBean
+	private SeatQueryService seatQueryService;
 
 	@Test
 	@DisplayName("애플리케이션 컨텍스트가 정상적으로 로드된다")

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/schedule/ScheduleControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/schedule/ScheduleControllerTest.java
@@ -1,0 +1,63 @@
+package com.ticketrush.centralserver.interfaces.api.schedule;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql(scripts = {
+	"/sql/cleanup.sql",
+	"/sql/schedule-controller-test-data.sql"
+})
+class ScheduleControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("특정 회차의 좌석을 조회할 수 있다.")
+	void 특정_회차의_좌석을_조회할_수_있다() throws Exception {
+		mockMvc.perform(get("/api/v1/schedules/1/seats"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.length()").value(3))
+			.andExpect(jsonPath("$.data[0].seatNumber").value("A1"))
+			.andExpect(jsonPath("$.data[1].seatNumber").value("A2"))
+			.andExpect(jsonPath("$.data[2].seatNumber").value("A3"))
+		;
+	}
+
+	@Test
+	@DisplayName("좌석의 상태를 특정해 조회할 수 있다.")
+	void 좌석의_상태를_특정해_조회할_수_있다() throws Exception {
+		mockMvc.perform(get("/api/v1/schedules/1/seats?status=AVAILABLE"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].seatNumber").value("A1"))
+			.andExpect(jsonPath("$.data[0].status").value("AVAILABLE"))
+		;
+	}
+
+	@Test
+	@DisplayName("두번째 회차의 좌석을 특정해 조회할 수 있다.")
+	void 두번째_회차의_좌석을_특정해_조회할_수_있다() throws Exception {
+		mockMvc.perform(get("/api/v1/schedules/2/seats"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.data.length()").value(1))
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data[0].seatNumber").value("B1"))
+			.andExpect(jsonPath("$.data[0].status").value("AVAILABLE"))
+		;
+	}
+}

--- a/central-server/src/test/resources/sql/schedule-controller-test-data.sql
+++ b/central-server/src/test/resources/sql/schedule-controller-test-data.sql
@@ -1,0 +1,20 @@
+INSERT INTO performance (title, description, venue, total_seats)
+VALUES ('테스트 공연', '설명', '올림픽홀', 500);
+
+INSERT INTO schedule (performance_id, start_time, end_time, status)
+VALUES (1, '2026-05-10 19:00:00', '2026-05-10 21:00:00', 'OPEN');
+
+INSERT INTO schedule (performance_id, start_time, end_time, status)
+VALUES (1, '2026-05-11 19:00:00', '2026-05-11 21:00:00', 'OPEN');
+
+INSERT INTO seat (schedule_id, seat_number, status, price)
+VALUES (1, 'A1', 'AVAILABLE', 50000);
+
+INSERT INTO seat (schedule_id, seat_number, status, price)
+VALUES (1, 'A2', 'HELD', 50000);
+
+INSERT INTO seat (schedule_id, seat_number, status, price)
+VALUES (1, 'A3', 'CONFIRMED', 50000);
+
+INSERT INTO seat (schedule_id, seat_number, status, price)
+VALUES (2, 'B1', 'AVAILABLE', 70000);


### PR DESCRIPTION
## 작업 내용
- 회차 ID 기반 좌석 조회 mapper 추가
- 좌석 조회 응답 DTO 추가
- 좌석 조회 서비스와 API 엔드포인트 추가
- status 조건 기반 좌석 필터 처리
- 좌석 조회 API 테스트 추가

## 확인한 것
- `GET /api/v1/schedules/{scheduleId}/seats` 정상 응답 확인
- `GET /api/v1/schedules/{scheduleId}/seats?status=AVAILABLE` 필터 조회 확인
- 특정 회차에 연결된 좌석 목록 조회 확인
- 다른 회차의 좌석이 섞이지 않는지 확인
- `./gradlew test` 통과

Close #16 
