### PR TITLE
feat: 조회 API 입력 검증 추가

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatQueryService.java
@@ -4,9 +4,12 @@ import java.util.List;
 
 import org.springframework.stereotype.Service;
 
+import com.ticketrush.centralserver.domain.seat.SeatStatus;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
 import com.ticketrush.centralserver.interfaces.api.schedule.dto.SeatResponse;
+import com.ticketrush.centralserver.support.exception.ApiException;
+import com.ticketrush.centralserver.support.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
 
@@ -17,6 +20,11 @@ public class SeatQueryService {
 	private final SeatQueryMapper seatQueryMapper;
 
 	public List<SeatResponse> getSeats(Long scheduleId, String status) {
+
+		if (!SeatStatus.isValid(status)){
+			throw new ApiException(ErrorCode.INVALID_SEAT_STATUS);
+		}
+
 		return seatQueryMapper.findByScheduleIdAndStatus(scheduleId, status).stream()
 			.map(this::toResponse)
 			.toList();

--- a/central-server/src/main/java/com/ticketrush/centralserver/domain/seat/SeatStatus.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/domain/seat/SeatStatus.java
@@ -9,8 +9,12 @@ public enum SeatStatus {
 	;
 
 	public static boolean isValid(String value) {
-		if (value == null || value.isBlank()) {
+		if (value == null) {
 			return true;
+		}
+
+		if (value.isBlank()) {
+			return false;
 		}
 
 		for (SeatStatus status : values()) {

--- a/central-server/src/main/java/com/ticketrush/centralserver/domain/seat/SeatStatus.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/domain/seat/SeatStatus.java
@@ -1,0 +1,26 @@
+package com.ticketrush.centralserver.domain.seat;
+
+public enum SeatStatus {
+
+	AVAILABLE,
+	HELD,
+	CONFIRMED,
+	CANCELLED
+	;
+
+	public static boolean isValid(String value) {
+		if (value == null || value.isBlank()) {
+			return true;
+		}
+
+		for (SeatStatus status : values()) {
+			if (status.name().equals(value)) {
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/support/exception/ErrorCode.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/support/exception/ErrorCode.java
@@ -6,6 +6,7 @@ public enum ErrorCode {
 	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "COMMON_INTERNAL_ERROR", "서버 내부 오류가 발생했습니다."),
 	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "잘못된 요청입니다."),
 	PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_NOT_FOUND", "공연을 찾을 수 없습니다."),
+	INVALID_SEAT_STATUS(HttpStatus.BAD_REQUEST, "INVALID_SEAT_STATUS", "허용하지 않는 좌석 상태입니다."),
 
 	;
 

--- a/central-server/src/main/java/com/ticketrush/centralserver/support/exception/GlobalExceptionHandler.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/support/exception/GlobalExceptionHandler.java
@@ -1,11 +1,13 @@
 package com.ticketrush.centralserver.support.exception;
 
-import com.ticketrush.centralserver.support.response.ApiResponse;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.FieldError;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+import com.ticketrush.centralserver.support.response.ApiResponse;
 
 @RestControllerAdvice
 public class GlobalExceptionHandler {
@@ -27,9 +29,16 @@ public class GlobalExceptionHandler {
 			.body(ApiResponse.failure(ErrorCode.VALIDATION_ERROR, message));
 	}
 
+	@ExceptionHandler(MethodArgumentTypeMismatchException.class)
+	public ResponseEntity<ApiResponse<Void>> handleTypeMismatchException(MethodArgumentTypeMismatchException e) {
+		return ResponseEntity.status(ErrorCode.VALIDATION_ERROR.status())
+			.body(ApiResponse.failure(ErrorCode.VALIDATION_ERROR));
+	}
+
 	@ExceptionHandler(Exception.class)
 	public ResponseEntity<ApiResponse<Void>> handleException(Exception e) {
 		return ResponseEntity.status(ErrorCode.INTERNAL_SERVER_ERROR.status())
 			.body(ApiResponse.failure(ErrorCode.INTERNAL_SERVER_ERROR));
 	}
+
 }

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/schedule/ScheduleControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/schedule/ScheduleControllerTest.java
@@ -33,8 +33,7 @@ class ScheduleControllerTest {
 			.andExpect(jsonPath("$.data.length()").value(3))
 			.andExpect(jsonPath("$.data[0].seatNumber").value("A1"))
 			.andExpect(jsonPath("$.data[1].seatNumber").value("A2"))
-			.andExpect(jsonPath("$.data[2].seatNumber").value("A3"))
-		;
+			.andExpect(jsonPath("$.data[2].seatNumber").value("A3"));
 	}
 
 	@Test
@@ -45,8 +44,7 @@ class ScheduleControllerTest {
 			.andExpect(jsonPath("$.data.length()").value(1))
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data[0].seatNumber").value("A1"))
-			.andExpect(jsonPath("$.data[0].status").value("AVAILABLE"))
-		;
+			.andExpect(jsonPath("$.data[0].status").value("AVAILABLE"));
 	}
 
 	@Test
@@ -57,7 +55,38 @@ class ScheduleControllerTest {
 			.andExpect(jsonPath("$.data.length()").value(1))
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data[0].seatNumber").value("B1"))
-			.andExpect(jsonPath("$.data[0].status").value("AVAILABLE"))
-		;
+			.andExpect(jsonPath("$.data[0].status").value("AVAILABLE"));
 	}
+
+	@Test
+	@DisplayName("잘못된 scheduleId 타입 요청 시 공통 에러 응답을 반환한다")
+	void 잘못된_scheduleId_타입() throws Exception {
+		mockMvc.perform(get("/api/v1/schedules/abc/seats"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("COMMON_INVALID_INPUT"))
+			.andExpect(jsonPath("$.error.message").value("잘못된 요청입니다."));
+	}
+
+	@Test
+	@DisplayName("허용하지 않는 좌석 상태 요청 시 공통 에러 응답을 반환한다")
+	void 허용하지_않는_좌석_상태_요청() throws Exception {
+		mockMvc.perform(get("/api/v1/schedules/1/seats?status=INVALID"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("INVALID_SEAT_STATUS"))
+			.andExpect(jsonPath("$.error.message").value("허용하지 않는 좌석 상태입니다."));
+	}
+
+	@Test
+	@DisplayName("빈 좌석 상태 요청 시 공통 에러 응답을 반환한다")
+	void 빈_좌석_상태_요청() throws Exception {
+		mockMvc.perform(get("/api/v1/schedules/1/seats?status="))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("INVALID_SEAT_STATUS"))
+			.andExpect(jsonPath("$.error.message").value("허용하지 않는 좌석 상태입니다."));
+	}
+
+
 }


### PR DESCRIPTION
## 작업 내용
- 잘못된 path variable 타입 요청에 대한 공통 에러 응답 처리 추가
- 좌석 status 허용값 검증 추가
- 허용하지 않는 좌석 status 요청에 대한 에러 응답 추가
- 입력 검증 실패 케이스 테스트 추가

## 확인한 것
- 잘못된 scheduleId 타입 요청 시 `400` 응답 확인
- 허용하지 않는 좌석 status 요청 시 `400` 응답 확인
- 빈 좌석 status 요청 시 `400` 응답 확인
- `./gradlew test --rerun-tasks` 통과

Close #18 