### PR TITLE
refactor: 조회 API 테스트 SQL 구조 정리

### DIFF
--- a/central-server/src/test/resources/sql/cleanup.sql
+++ b/central-server/src/test/resources/sql/cleanup.sql
@@ -1,3 +1,6 @@
+-- 조회 API 통합 테스트 공통 정리 스크립트
+-- FK 제약을 고려해 자식 테이블부터 삭제하고, AUTO_INCREMENT 값을 초기화한다.
+
 DELETE FROM payment;
 DELETE FROM reservation;
 DELETE FROM seat;

--- a/central-server/src/test/resources/sql/performance-controller-test-data.sql
+++ b/central-server/src/test/resources/sql/performance-controller-test-data.sql
@@ -1,3 +1,6 @@
+-- PerformanceControllerTest 전용 테스트 데이터
+-- 공연 목록/단건 조회와 공연별 회차 조회를 검증한다.
+
 INSERT INTO performance (title, description, venue, total_seats)
 VALUES ('테스트 공연', '설명', '올림픽홀', 500);
 

--- a/central-server/src/test/resources/sql/schedule-controller-test-data.sql
+++ b/central-server/src/test/resources/sql/schedule-controller-test-data.sql
@@ -1,6 +1,10 @@
+-- ScheduleControllerTest 전용 테스트 데이터
+-- 회차별 좌석 목록 조회와 status 필터 조회를 검증한다.
+
 INSERT INTO performance (title, description, venue, total_seats)
 VALUES ('테스트 공연', '설명', '올림픽홀', 500);
 
+-- 회차 정렬 검증을 위해 start_time 순서와 삽입 순서를 다르게 둔다.
 INSERT INTO schedule (performance_id, start_time, end_time, status)
 VALUES (1, '2026-05-10 19:00:00', '2026-05-10 21:00:00', 'OPEN');
 


### PR DESCRIPTION
## 작업 내용
- 조회 API 통합 테스트 공통 cleanup SQL의 역할 설명 추가
- 공연 조회 API 테스트 데이터 SQL의 사용 목적 설명 추가
- 좌석 조회 API 테스트 데이터 SQL의 사용 목적 설명 추가
- 회차 정렬 검증용 테스트 데이터 의도 설명 추가

## 확인한 것
- `./gradlew test --rerun-tasks` 통과

Close #20 