### PR TITLE
feat: 좌석 상태 전이 규칙 정의

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/domain/seat/SeatStatus.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/domain/seat/SeatStatus.java
@@ -8,6 +8,19 @@ public enum SeatStatus {
 	CANCELLED
 	;
 
+	public boolean canTransitionTo(SeatStatus nextStatus) {
+		if (nextStatus == null) {
+			return false;
+		}
+
+		return switch (this) {
+			case AVAILABLE -> nextStatus == HELD;
+			case HELD -> nextStatus == CONFIRMED || nextStatus == AVAILABLE;
+			case CONFIRMED -> nextStatus == CANCELLED;
+			case CANCELLED -> false;
+		};
+	}
+
 	public static boolean isValid(String value) {
 		if (value == null) {
 			return true;

--- a/central-server/src/test/java/com/ticketrush/centralserver/domain/seat/SeatStatusTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/domain/seat/SeatStatusTest.java
@@ -1,0 +1,27 @@
+package com.ticketrush.centralserver.domain.seat;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SeatStatusTest {
+	@Test
+	@DisplayName("허용되는 좌석 상태 전이는 true를 반환한다")
+	void 허용되는_상태_전이() {
+		assertThat(SeatStatus.AVAILABLE.canTransitionTo(SeatStatus.HELD)).isTrue();
+		assertThat(SeatStatus.HELD.canTransitionTo(SeatStatus.CONFIRMED)).isTrue();
+		assertThat(SeatStatus.HELD.canTransitionTo(SeatStatus.AVAILABLE)).isTrue();
+		assertThat(SeatStatus.CONFIRMED.canTransitionTo(SeatStatus.CANCELLED)).isTrue();
+	}
+
+	@Test
+	@DisplayName("허용되지 않는 좌석 상태 전이는 false를 반환한다")
+	void 허용되지_않는_상태_전이() {
+		assertThat(SeatStatus.AVAILABLE.canTransitionTo(SeatStatus.CONFIRMED)).isFalse();
+		assertThat(SeatStatus.AVAILABLE.canTransitionTo(SeatStatus.CANCELLED)).isFalse();
+		assertThat(SeatStatus.CONFIRMED.canTransitionTo(SeatStatus.HELD)).isFalse();
+		assertThat(SeatStatus.CANCELLED.canTransitionTo(SeatStatus.HELD)).isFalse();
+		assertThat(SeatStatus.AVAILABLE.canTransitionTo(null)).isFalse();
+	}
+}


### PR DESCRIPTION
## 작업 내용
- 좌석 상태 전이 규칙 추가
- 허용되는 상태 전이 정의
- 허용되지 않는 상태 전이 테스트 추가
- null 전이 요청에 대한 테스트 추가

## 확인한 것
- `AVAILABLE -> HELD` 허용
- `HELD -> CONFIRMED` 허용
- `HELD -> AVAILABLE` 허용
- `CONFIRMED -> CANCELLED` 허용
- 허용하지 않는 상태 전이는 false 반환
- `./gradlew test --rerun-tasks` 통과

Close #24 
