### PR TITLE
좌석 임시 점유 API 기본 흐름 추가

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatHoldService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatHoldService.java
@@ -1,0 +1,34 @@
+package com.ticketrush.centralserver.application.seat;
+
+import org.springframework.stereotype.Service;
+
+import com.ticketrush.centralserver.domain.seat.SeatStatus;
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
+import com.ticketrush.centralserver.interfaces.api.seat.dto.SeatHoldResponse;
+import com.ticketrush.centralserver.support.exception.ApiException;
+import com.ticketrush.centralserver.support.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class SeatHoldService {
+
+	private final SeatQueryMapper seatQueryMapper;
+
+	public SeatHoldResponse holdSeat(Long seatId) {
+		SeatRow seat = seatQueryMapper.findById(seatId)
+			.orElseThrow(() -> new ApiException(ErrorCode.SEAT_NOT_FOUND));
+
+		SeatStatus currentStatus = SeatStatus.valueOf(seat.status());
+
+		if (!currentStatus.canTransitionTo(SeatStatus.HELD)) {
+			throw new ApiException(ErrorCode.SEAT_CANNOT_BE_HELD);
+		}
+
+		seatQueryMapper.holdSeat(seatId);
+
+		return new SeatHoldResponse(seat.id(), SeatStatus.HELD.name());
+	}
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
@@ -1,6 +1,7 @@
 package com.ticketrush.centralserver.infrastructure.persistence.mapper;
 
 import java.util.List;
+import java.util.Optional;
 
 import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
@@ -11,5 +12,9 @@ import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
 public interface SeatQueryMapper {
 
 	List<SeatRow> findByScheduleIdAndStatus(@Param("scheduleId") Long scheduleId, @Param("status") String status);
+
+	Optional<SeatRow> findById(@Param("seatId") Long seatId);
+
+	int holdSeat(@Param("seatId") Long seatId);
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/SeatController.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/SeatController.java
@@ -1,0 +1,26 @@
+package com.ticketrush.centralserver.interfaces.api.seat;
+
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.ticketrush.centralserver.application.seat.SeatHoldService;
+import com.ticketrush.centralserver.interfaces.api.seat.dto.SeatHoldResponse;
+import com.ticketrush.centralserver.support.response.ApiResponse;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/api/v1/seats")
+@RequiredArgsConstructor
+public class SeatController {
+
+	private final SeatHoldService seatHoldService;
+
+	@PostMapping("/{seatId}/hold")
+	public ApiResponse<SeatHoldResponse> holdSeat(@PathVariable Long seatId) {
+		return ApiResponse.success(seatHoldService.holdSeat(seatId));
+	}
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatHoldRequest.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatHoldRequest.java
@@ -1,0 +1,4 @@
+package com.ticketrush.centralserver.interfaces.api.seat.dto;
+
+public record SeatHoldRequest() {
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatHoldRequest.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatHoldRequest.java
@@ -1,4 +1,0 @@
-package com.ticketrush.centralserver.interfaces.api.seat.dto;
-
-public record SeatHoldRequest() {
-}

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatHoldResponse.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatHoldResponse.java
@@ -1,0 +1,7 @@
+package com.ticketrush.centralserver.interfaces.api.seat.dto;
+
+public record SeatHoldResponse(
+	Long seatId,
+	String status
+) {
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/support/exception/ErrorCode.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/support/exception/ErrorCode.java
@@ -7,6 +7,8 @@ public enum ErrorCode {
 	VALIDATION_ERROR(HttpStatus.BAD_REQUEST, "COMMON_INVALID_INPUT", "잘못된 요청입니다."),
 	PERFORMANCE_NOT_FOUND(HttpStatus.NOT_FOUND, "PERFORMANCE_NOT_FOUND", "공연을 찾을 수 없습니다."),
 	INVALID_SEAT_STATUS(HttpStatus.BAD_REQUEST, "INVALID_SEAT_STATUS", "허용하지 않는 좌석 상태입니다."),
+	SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "SEAT_NOT_FOUND", "좌석을 찾을 수 없습니다."),
+	SEAT_CANNOT_BE_HELD(HttpStatus.BAD_REQUEST, "SEAT_CANNOT_BE_HELD", "점유할 수 없는 좌석입니다."),
 
 	;
 

--- a/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
+++ b/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
@@ -19,4 +19,22 @@
         ORDER BY seat_number ASC, id ASC
     </select>
 
+    <select id="findById" resultType="com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow">
+        SELECT
+            id,
+            schedule_id,
+            seat_number,
+            status,
+            price
+        FROM seat
+        WHERE id = #{seatId}
+    </select>
+
+    <update id="holdSeat">
+        UPDATE seat
+            SET status = 'HELD',
+                held_at = CURRENT_TIMESTAMP
+        WHERE id = #{seatId}
+    </update>
+
 </mapper>

--- a/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
@@ -8,6 +8,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import com.ticketrush.centralserver.application.performance.PerformanceQueryService;
 import com.ticketrush.centralserver.application.schedule.ScheduleQueryService;
+import com.ticketrush.centralserver.application.seat.SeatHoldService;
 import com.ticketrush.centralserver.application.seat.SeatQueryService;
 
 @SpringBootTest(
@@ -24,6 +25,9 @@ class CentralServerApplicationTests {
 
 	@MockitoBean
 	private SeatQueryService seatQueryService;
+
+	@MockitoBean
+	private SeatHoldService seatHoldService;
 
 	@Test
 	@DisplayName("애플리케이션 컨텍스트가 정상적으로 로드된다")

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
@@ -1,0 +1,88 @@
+package com.ticketrush.centralserver.interfaces.api.seat;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.web.servlet.MockMvc;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+@ActiveProfiles("test")
+@Sql(scripts = {
+	"/sql/cleanup.sql",
+	"/sql/seat-controller-test-data.sql"
+})
+class SeatControllerTest {
+
+	@Autowired
+	private MockMvc mockMvc;
+
+	@Test
+	@DisplayName("AVAILABLE 상태의 좌석을 HELD 상태로 점유할 수 있다")
+	void available_좌석_점유_성공() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/1/hold"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.seatId").value(1))
+			.andExpect(jsonPath("$.data.status").value("HELD"));
+	}
+
+	@Test
+	@DisplayName("HELD 상태의 좌석은 다시 점유할 수 없다")
+	void held_좌석_점유_실패() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/2/hold"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_HELD"))
+			.andExpect(jsonPath("$.error.message").value("점유할 수 없는 좌석입니다."));
+	}
+
+	@Test
+	@DisplayName("CONFIRMED 상태의 좌석은 점유할 수 없다")
+	void confirmed_좌석_점유_실패() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/3/hold"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_HELD"))
+			.andExpect(jsonPath("$.error.message").value("점유할 수 없는 좌석입니다."));
+	}
+
+	@Test
+	@DisplayName("CANCELLED 상태의 좌석은 점유할 수 없다")
+	void cancelled_좌석_점유_실패() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/4/hold"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_HELD"))
+			.andExpect(jsonPath("$.error.message").value("점유할 수 없는 좌석입니다."));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 좌석은 점유할 수 없다")
+	void 존재하지_않는_좌석_점유_실패() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/9999/hold"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("SEAT_NOT_FOUND"))
+			.andExpect(jsonPath("$.error.message").value("좌석을 찾을 수 없습니다."));
+	}
+
+	@Test
+	@DisplayName("잘못된 seatId 타입 요청 시 공통 에러 응답을 반환한다")
+	void 잘못된_seatId_타입_요청() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/abc/hold"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("COMMON_INVALID_INPUT"))
+			.andExpect(jsonPath("$.error.message").value("잘못된 요청입니다."));
+	}
+
+
+}

--- a/central-server/src/test/resources/sql/seat-controller-test-data.sql
+++ b/central-server/src/test/resources/sql/seat-controller-test-data.sql
@@ -1,0 +1,20 @@
+-- SeatControllerTest 전용 테스트 데이터
+-- 좌석 임시 점유 성공과 상태별 실패 케이스를 검증한다.
+
+INSERT INTO performance (title, description, venue, total_seats)
+VALUES ('좌석 점유 테스트 공연', '설명', '올림픽홀', 4);
+
+INSERT INTO schedule (performance_id, start_time, end_time, status)
+VALUES (1, '2026-05-10 19:00:00', '2026-05-10 21:00:00', 'OPEN');
+
+INSERT INTO seat (schedule_id, seat_number, status, price)
+VALUES (1, 'A1', 'AVAILABLE', 50000);
+
+INSERT INTO seat (schedule_id, seat_number, status, price, held_at)
+VALUES (1, 'A2', 'HELD', 50000, CURRENT_TIMESTAMP);
+
+INSERT INTO seat (schedule_id, seat_number, status, price)
+VALUES (1, 'A3', 'CONFIRMED', 50000);
+
+INSERT INTO seat (schedule_id, seat_number, status, price)
+VALUES (1, 'A4', 'CANCELLED', 50000);


### PR DESCRIPTION
## 작업 내용

- 좌석 임시 점유 API의 기본 흐름 구현
- 좌석 조회 후 상태 전이 규칙을 검증하고, AVAILABLE 상태만 HELD 상태로 변경
- 점유 불가 상태와 존재하지 않는 좌석에 대한 공통 에러 응답 처리
- 좌석 점유 API 성공/실패 테스트 추가

## 테스트

- `./gradlew test`

close #30 