### PR TITLE
Pessimistic Lock 기반 좌석 점유 동시성 제어 적용

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatHoldService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatHoldService.java
@@ -1,6 +1,7 @@
 package com.ticketrush.centralserver.application.seat;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketrush.centralserver.domain.seat.SeatStatus;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
@@ -17,8 +18,9 @@ public class SeatHoldService {
 
 	private final SeatQueryMapper seatQueryMapper;
 
+	@Transactional
 	public SeatHoldResponse holdSeat(Long seatId) {
-		SeatRow seat = seatQueryMapper.findById(seatId)
+		SeatRow seat = seatQueryMapper.findByIdForUpdate(seatId)
 			.orElseThrow(() -> new ApiException(ErrorCode.SEAT_NOT_FOUND));
 
 		SeatStatus currentStatus = SeatStatus.valueOf(seat.status());

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
@@ -17,4 +17,6 @@ public interface SeatQueryMapper {
 
 	int holdSeat(@Param("seatId") Long seatId);
 
+	Optional<SeatRow> findByIdForUpdate(@Param("seatId") Long seatId);
+
 }

--- a/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
+++ b/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
@@ -37,4 +37,16 @@
         WHERE id = #{seatId}
     </update>
 
+    <select id="findByIdForUpdate" resultType="com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow">
+        SELECT
+            id,
+            schedule_id,
+            seat_number,
+            status,
+            price
+        FROM seat
+        WHERE id = #{seatId}
+        FOR UPDATE
+    </select>
+
 </mapper>

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
@@ -1,7 +1,14 @@
 package com.ticketrush.centralserver.interfaces.api.seat;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -84,5 +91,50 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.error.message").value("잘못된 요청입니다."));
 	}
 
+	@Test
+	@DisplayName("동일 좌석에 동시에 점유 요청이 들어오면 하나만 성공한다")
+	void 동일_좌석_동시_점유_요청_하나만_성공() throws Exception{
+
+		int threadCount = 10;
+
+		ExecutorService executorService = Executors.newFixedThreadPool(threadCount);
+		CountDownLatch startLatch = new CountDownLatch(1);
+		CountDownLatch doneLatch = new CountDownLatch(threadCount);
+
+		AtomicInteger successCount = new AtomicInteger();
+		AtomicInteger failureCount = new AtomicInteger();
+
+		for (int i = 0; i < threadCount; i++) {
+			executorService.submit(() -> {
+				try {
+					startLatch.await();
+
+					int status = mockMvc.perform(post("/api/v1/seats/1/hold"))
+						.andReturn()
+						.getResponse()
+						.getStatus();
+
+					if (status == 200) {
+						successCount.incrementAndGet();
+					} else {
+						failureCount.incrementAndGet();
+					}
+				} catch (Exception e) {
+					throw new RuntimeException(e);
+				} finally {
+					doneLatch.countDown();
+				}
+			});
+		}
+		startLatch.countDown();
+
+		boolean finished = doneLatch.await(5, TimeUnit.SECONDS);
+
+		executorService.shutdown();
+
+		assertTrue(finished);
+		assertEquals(1, successCount.get());
+		assertEquals(9, failureCount.get());
+	}
 
 }


### PR DESCRIPTION
## 작업 내용

- 좌석 조회 시 row lock을 획득하는 mapper 추가
- 좌석 점유 흐름을 트랜잭션 안에서 처리하도록 변경
- 상태 확인과 HELD 상태 변경을 같은 트랜잭션 경계에서 처리
- 동일 좌석 동시 점유 요청 시 하나의 요청만 성공하는 테스트 추가

## 테스트

- `./gradlew test`

close #32 