### PR TITLE
PR 테스트 자동화를 위한 GitHub Actions 구성

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,55 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: 17
+          cache: gradle
+          cache-dependency-path: |
+            central-server/*.gradle*
+            central-server/gradle/wrapper/gradle-wrapper.properties
+
+      - name: Ensure Gradle wrapper is executable
+        working-directory: central-server
+        run: chmod +x ./gradlew
+
+      - name: Start MySQL
+        run: docker compose up -d mysql-master
+
+      - name: Wait for MySQL
+        run: |
+          for i in {1..30}; do
+            if docker compose exec -T mysql-master mysqladmin ping -h localhost -prootpassword --silent; then
+              exit 0
+            fi
+
+            sleep 2
+          done
+
+          docker compose logs mysql-master
+          exit 1
+
+      - name: Run tests
+        working-directory: central-server
+        run: ./gradlew test


### PR DESCRIPTION
## 작업 내용

- PR과 main 브랜치 push 시 central-server 테스트를 자동 실행하도록 GitHub Actions workflow 구성
- Java 17과 Gradle 캐시 설정
- 테스트 실행 전 MySQL 컨테이너를 기동하고 준비 상태 확인
- `central-server` 경로에서 `./gradlew test` 실행

## 테스트

- GitHub Actions PR check에서 확인

close #34 