### PR TITLE
좌석 홀드 취소 및 만료 복구 로직 구현

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseCommand.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseCommand.java
@@ -1,0 +1,6 @@
+package com.ticketrush.centralserver.application.seat;
+
+public record SeatReleaseCommand(
+	Long seatId
+) {
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseService.java
@@ -1,5 +1,8 @@
 package com.ticketrush.centralserver.application.seat;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -41,6 +44,25 @@ public class SeatReleaseService {
 		}
 
 		return new SeatReleaseResponse(seatId, AVAILABLE);
+	}
+
+	@Transactional
+	public int releaseExpiredSeats(LocalDateTime threshold) {
+
+		List<SeatRow> expiredSeats = seatQueryMapper.findExpiredHeldSeats(threshold);
+
+		int totalReleaseCount = 0;
+		for (SeatRow seat : expiredSeats) {
+			int releaseCount = seatQueryMapper.releaseSeat(seat.id());
+
+			if (releaseCount != 1) {
+				throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+			}
+
+			totalReleaseCount += releaseCount;
+		}
+
+		return totalReleaseCount;
 	}
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseService.java
@@ -1,15 +1,46 @@
 package com.ticketrush.centralserver.application.seat;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import com.ticketrush.centralserver.domain.seat.SeatStatus;
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
 import com.ticketrush.centralserver.interfaces.api.seat.dto.SeatReleaseResponse;
+import com.ticketrush.centralserver.support.exception.ApiException;
+import com.ticketrush.centralserver.support.exception.ErrorCode;
 
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
 @Service
 public class SeatReleaseService {
 
+	private static final String AVAILABLE = "AVAILABLE";
+
+	private final SeatQueryMapper seatQueryMapper;
+
+	@Transactional
 	public SeatReleaseResponse releaseSeat(SeatReleaseCommand command) {
 
-		return new SeatReleaseResponse(command.seatId(), "AVAILABLE");
+		Long seatId = command.seatId();
+
+		SeatRow seat = seatQueryMapper.findByIdForUpdate(seatId)
+			.orElseThrow(() -> new ApiException(ErrorCode.SEAT_NOT_FOUND));
+
+		SeatStatus currentStatus = SeatStatus.from(seat.status());
+
+		if (!currentStatus.canTransitionTo(SeatStatus.AVAILABLE)) {
+			throw new ApiException(ErrorCode.SEAT_CANNOT_BE_RELEASED);
+		}
+
+		int releaseCount = seatQueryMapper.releaseSeat(seatId);
+
+		if (releaseCount != 1) {
+			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
+		}
+
+		return new SeatReleaseResponse(seatId, AVAILABLE);
 	}
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseService.java
@@ -1,0 +1,15 @@
+package com.ticketrush.centralserver.application.seat;
+
+import org.springframework.stereotype.Service;
+
+import com.ticketrush.centralserver.interfaces.api.seat.dto.SeatReleaseResponse;
+
+@Service
+public class SeatReleaseService {
+
+	public SeatReleaseResponse releaseSeat(SeatReleaseCommand command) {
+
+		return new SeatReleaseResponse(command.seatId(), "AVAILABLE");
+	}
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
@@ -1,5 +1,6 @@
 package com.ticketrush.centralserver.infrastructure.persistence.mapper;
 
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -24,5 +25,7 @@ public interface SeatQueryMapper {
 	int confirmSeat(@Param("seatId") Long seatId);
 
 	int releaseSeat(@Param("seatId") Long seatId);
+
+	List<SeatRow> findExpiredHeldSeats(@Param("threshold") LocalDateTime threshold);
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/persistence/mapper/SeatQueryMapper.java
@@ -23,4 +23,6 @@ public interface SeatQueryMapper {
 
 	int confirmSeat(@Param("seatId") Long seatId);
 
+	int releaseSeat(@Param("seatId") Long seatId);
+
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/SeatController.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/SeatController.java
@@ -6,7 +6,10 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.ticketrush.centralserver.application.seat.SeatHoldService;
+import com.ticketrush.centralserver.application.seat.SeatReleaseCommand;
+import com.ticketrush.centralserver.application.seat.SeatReleaseService;
 import com.ticketrush.centralserver.interfaces.api.seat.dto.SeatHoldResponse;
+import com.ticketrush.centralserver.interfaces.api.seat.dto.SeatReleaseResponse;
 import com.ticketrush.centralserver.support.response.ApiResponse;
 
 import lombok.RequiredArgsConstructor;
@@ -17,10 +20,16 @@ import lombok.RequiredArgsConstructor;
 public class SeatController {
 
 	private final SeatHoldService seatHoldService;
+	private final SeatReleaseService seatReleaseService;
 
 	@PostMapping("/{seatId}/hold")
 	public ApiResponse<SeatHoldResponse> holdSeat(@PathVariable Long seatId) {
 		return ApiResponse.success(seatHoldService.holdSeat(seatId));
+	}
+
+	@PostMapping("/{seatId}/release")
+	public ApiResponse<SeatReleaseResponse> releaseSeat(@PathVariable Long seatId) {
+		return ApiResponse.success(seatReleaseService.releaseSeat(new SeatReleaseCommand(seatId)));
 	}
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatReleaseRequest.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatReleaseRequest.java
@@ -1,0 +1,5 @@
+package com.ticketrush.centralserver.interfaces.api.seat.dto;
+
+public record SeatReleaseRequest(
+) {
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatReleaseResponse.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/interfaces/api/seat/dto/SeatReleaseResponse.java
@@ -1,0 +1,7 @@
+package com.ticketrush.centralserver.interfaces.api.seat.dto;
+
+public record SeatReleaseResponse(
+	Long seatId,
+	String status
+) {
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/support/exception/ErrorCode.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/support/exception/ErrorCode.java
@@ -10,6 +10,7 @@ public enum ErrorCode {
 	SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "SEAT_NOT_FOUND", "좌석을 찾을 수 없습니다."),
 	SEAT_CANNOT_BE_HELD(HttpStatus.BAD_REQUEST, "SEAT_CANNOT_BE_HELD", "점유할 수 없는 좌석입니다."),
 	SEAT_CANNOT_BE_CONFIRMED(HttpStatus.BAD_REQUEST, "SEAT_CANNOT_BE_CONFIRMED", "확정할 수 없는 좌석입니다."),
+	SEAT_CANNOT_BE_RELEASED(HttpStatus.BAD_REQUEST, "SEAT_CANNOT_BE_RELEASED", "해제할 수 없는 좌석입니다."),
 
 	;
 

--- a/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
+++ b/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
@@ -60,8 +60,17 @@
     <update id="confirmSeat">
         UPDATE seat
         SET status = 'CONFIRMED',
-        held_at = NULL
+            held_at = NULL
         WHERE id = #{seatId}
-        AND status = 'HELD'
+          AND status = 'HELD'
     </update>
+
+    <update id="releaseSeat">
+        UPDATE seat
+        SET status = 'AVAILABLE',
+            held_at = NULL
+        WHERE id = #{seatId}
+          AND status = 'HELD'
+    </update>
+
 </mapper>

--- a/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
+++ b/central-server/src/main/resources/mapper/seat/SeatQueryMapper.xml
@@ -59,18 +59,31 @@
 
     <update id="confirmSeat">
         UPDATE seat
-        SET status = 'CONFIRMED',
-            held_at = NULL
+            SET status = 'CONFIRMED',
+                held_at = NULL
         WHERE id = #{seatId}
           AND status = 'HELD'
     </update>
 
     <update id="releaseSeat">
         UPDATE seat
-        SET status = 'AVAILABLE',
-            held_at = NULL
+            SET status = 'AVAILABLE',
+                held_at = NULL
         WHERE id = #{seatId}
           AND status = 'HELD'
     </update>
+
+    <select id="findExpiredHeldSeats" resultType="com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow">
+        SELECT
+            id,
+            schedule_id,
+            seat_number,
+            status,
+            price
+        FROM seat
+        WHERE status = 'HELD'
+          AND held_at <![CDATA[ < ]]> #{threshold}
+        ORDER BY held_at ASC, id ASC
+    </select>
 
 </mapper>

--- a/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/CentralServerApplicationTests.java
@@ -11,6 +11,7 @@ import com.ticketrush.centralserver.application.reservation.ReservationConfirmSe
 import com.ticketrush.centralserver.application.schedule.ScheduleQueryService;
 import com.ticketrush.centralserver.application.seat.SeatHoldService;
 import com.ticketrush.centralserver.application.seat.SeatQueryService;
+import com.ticketrush.centralserver.application.seat.SeatReleaseService;
 
 @SpringBootTest(
 	properties = "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration"
@@ -32,6 +33,9 @@ class CentralServerApplicationTests {
 
 	@MockitoBean
 	private ReservationConfirmService reservationConfirmService;
+
+	@MockitoBean
+	private SeatReleaseService seatReleaseService;
 
 	@Test
 	@DisplayName("애플리케이션 컨텍스트가 정상적으로 로드된다")

--- a/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatReleaseServiceTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatReleaseServiceTest.java
@@ -1,0 +1,48 @@
+package com.ticketrush.centralserver.application.seat;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
+
+@SpringBootTest
+@ActiveProfiles("test")
+@Sql(scripts = {
+	"/sql/cleanup.sql",
+	"/sql/seat-controller-test-data.sql"
+})
+class SeatReleaseServiceTest {
+
+	@Autowired
+	private SeatReleaseService seatReleaseService;
+
+	@Autowired
+	private SeatQueryMapper seatQueryMapper;
+
+
+	@Test
+	@DisplayName("만료된 좌석을 복구할 수 있다")
+	void 만료된_좌석_복구_성공() {
+		LocalDateTime threshold = LocalDateTime.of(2026, 5, 10, 18, 50, 0);
+
+		int releasedCount = seatReleaseService.releaseExpiredSeats(threshold);
+
+		SeatRow expiredSeat = seatQueryMapper.findById(2L).orElseThrow();
+		SeatRow recentSeat = seatQueryMapper.findById(5L).orElseThrow();
+
+		assertEquals(1, releasedCount);
+		assertEquals("AVAILABLE", expiredSeat.status());
+		assertEquals("HELD", recentSeat.status());
+	}
+
+
+}

--- a/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatReleaseServiceTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatReleaseServiceTest.java
@@ -44,5 +44,20 @@ class SeatReleaseServiceTest {
 		assertEquals("HELD", recentSeat.status());
 	}
 
+	@Test
+	@DisplayName("만료된 좌석이 없으면 0건을 반환한다")
+	void 만료된_좌석이_없으면_0건을_반환한다() {
+		LocalDateTime threshold = LocalDateTime.of(2026, 5, 10, 18, 30, 0);
+
+		int releasedCount = seatReleaseService.releaseExpiredSeats(threshold);
+
+		SeatRow expiredCandidate = seatQueryMapper.findById(2L).orElseThrow();
+		SeatRow recentSeat = seatQueryMapper.findById(5L).orElseThrow();
+
+		assertEquals(0, releasedCount);
+		assertEquals("HELD", expiredCandidate.status());
+		assertEquals("HELD", recentSeat.status());
+	}
+
 
 }

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
@@ -137,4 +137,54 @@ class SeatControllerTest {
 		assertEquals(9, failureCount.get());
 	}
 
+	@Test
+	@DisplayName("HELD 상태의 좌석을 AVAILABLE 상태로 해제할 수 있다")
+	void held_좌석_해제_성공() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/2/release"))
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.success").value(true))
+			.andExpect(jsonPath("$.data.seatId").value(2))
+			.andExpect(jsonPath("$.data.status").value("AVAILABLE"));
+	}
+
+	@Test
+	@DisplayName("AVAILABLE 상태의 좌석은 해제할 수 없다")
+	void available_좌석_해제_실패() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/1/release"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_RELEASED"))
+			.andExpect(jsonPath("$.error.message").value("해제할 수 없는 좌석입니다."));
+	}
+
+	@Test
+	@DisplayName("CONFIRMED 상태의 좌석은 해제할 수 없다")
+	void confirmed_좌석_해제_실패() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/3/release"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_RELEASED"))
+			.andExpect(jsonPath("$.error.message").value("해제할 수 없는 좌석입니다."));
+	}
+
+	@Test
+	@DisplayName("CANCELLED 상태의 좌석은 해제할 수 없다")
+	void cancelled_좌석_해제_실패() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/4/release"))
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_RELEASED"))
+			.andExpect(jsonPath("$.error.message").value("해제할 수 없는 좌석입니다."));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 좌석은 해제할 수 없다")
+	void 존재하지_않는_좌석_해제_실패() throws Exception{
+		mockMvc.perform(post("/api/v1/seats/9999/release"))
+			.andExpect(status().isNotFound())
+			.andExpect(jsonPath("$.success").value(false))
+			.andExpect(jsonPath("$.error.code").value("SEAT_NOT_FOUND"))
+			.andExpect(jsonPath("$.error.message").value("좌석을 찾을 수 없습니다."));
+	}
+
 }

--- a/central-server/src/test/resources/sql/cleanup.sql
+++ b/central-server/src/test/resources/sql/cleanup.sql
@@ -1,4 +1,4 @@
--- 조회 API 통합 테스트 공통 정리 스크립트
+-- 통합 테스트 공통 정리 스크립트
 -- FK 제약을 고려해 자식 테이블부터 삭제하고, AUTO_INCREMENT 값을 초기화한다.
 
 DELETE FROM payment;

--- a/central-server/src/test/resources/sql/seat-controller-test-data.sql
+++ b/central-server/src/test/resources/sql/seat-controller-test-data.sql
@@ -1,8 +1,8 @@
 -- SeatControllerTest 전용 테스트 데이터
--- 좌석 임시 점유 성공과 상태별 실패 케이스를 검증한다.
+-- 좌석 점유, 해제, 만료 복구 시나리오를 함께 검증한다.
 
 INSERT INTO performance (title, description, venue, total_seats)
-VALUES ('좌석 점유 테스트 공연', '설명', '올림픽홀', 4);
+VALUES ('좌석 점유 테스트 공연', '설명', '올림픽홀', 5);
 
 INSERT INTO schedule (performance_id, start_time, end_time, status)
 VALUES (1, '2026-05-10 19:00:00', '2026-05-10 21:00:00', 'OPEN');
@@ -11,10 +11,13 @@ INSERT INTO seat (schedule_id, seat_number, status, price)
 VALUES (1, 'A1', 'AVAILABLE', 50000);
 
 INSERT INTO seat (schedule_id, seat_number, status, price, held_at)
-VALUES (1, 'A2', 'HELD', 50000, CURRENT_TIMESTAMP);
+VALUES (1, 'A2', 'HELD', 50000, '2026-05-10 18:40:00');
 
 INSERT INTO seat (schedule_id, seat_number, status, price)
 VALUES (1, 'A3', 'CONFIRMED', 50000);
 
 INSERT INTO seat (schedule_id, seat_number, status, price)
 VALUES (1, 'A4', 'CANCELLED', 50000);
+
+INSERT INTO seat (schedule_id, seat_number, status, price, held_at)
+VALUES (1, 'A5', 'HELD', 50000, '2026-05-10 18:59:30');


### PR DESCRIPTION
## 작업 내용
- 좌석 점유 해제 API 추가
- `HELD -> AVAILABLE` 상태 전이와 `held_at` 초기화 처리
- 만료 대상 좌석 조회 SQL 추가
- 기준 시각 이전 `HELD` 좌석 복구 로직 추가
- 좌석 해제 API 테스트 추가
- 만료 복구 서비스 테스트 추가
- 애플리케이션 컨텍스트 테스트 mock 의존성 보강

## 확인한 것
- `HELD` 상태 좌석만 해제되도록 처리
- `AVAILABLE`, `CONFIRMED`, `CANCELLED` 상태 좌석 해제 실패 응답 확인
- 기준 시각 이전 `HELD` 좌석만 만료 복구 대상에 포함되는지 확인
- `./gradlew test` 전체 통과 확인

## 테스트
- `./gradlew test`

Close #42 