### PR TITLE
예매 트랜잭션 통합 테스트 확장

### DIFF
--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/reservation/ReservationControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/reservation/ReservationControllerTest.java
@@ -1,5 +1,6 @@
 package com.ticketrush.centralserver.interfaces.api.reservation;
 
+import static org.junit.jupiter.api.Assertions.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
@@ -8,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
@@ -23,6 +25,9 @@ class ReservationControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
+
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
 
 	@Test
 	@DisplayName("HELD 좌석을 예매하면 확정 성공한다")
@@ -43,6 +48,11 @@ class ReservationControllerTest {
 			.andExpect(jsonPath("$.data.reservationStatus").value("CONFIRMED"))
 			.andExpect(jsonPath("$.data.paymentStatus").value("PENDING"))
 			.andExpect(jsonPath("$.data.amount").value(50000));
+		assertEquals("CONFIRMED", seatStatus(1L));
+		assertEquals(1, reservationCount(1L));
+		assertEquals(1, paymentCount(1L));
+		assertEquals("CONFIRMED", reservationStatus(1L));
+		assertEquals("PENDING", paymentStatus(1L));
 	}
 
 	@Test
@@ -60,6 +70,9 @@ class ReservationControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_NOT_FOUND"))
 			.andExpect(jsonPath("$.error.message").value("좌석을 찾을 수 없습니다."));
+
+		assertEquals(0, reservationCount(4L));
+		assertEquals(0, paymentCount(4L));
 	}
 
 	@Test
@@ -77,6 +90,10 @@ class ReservationControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_CONFIRMED"))
 			.andExpect(jsonPath("$.error.message").value("확정할 수 없는 좌석입니다."));
+
+		assertEquals("AVAILABLE", seatStatus(2L));
+		assertEquals(0, reservationCount(2L));
+		assertEquals(0, paymentCount(2L));
 	}
 
 	@Test
@@ -94,6 +111,10 @@ class ReservationControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_CONFIRMED"))
 			.andExpect(jsonPath("$.error.message").value("확정할 수 없는 좌석입니다."));
+
+		assertEquals("CONFIRMED", seatStatus(3L));
+		assertEquals(0, reservationCount(3L));
+		assertEquals(0, paymentCount(3L));
 	}
 
 	@Test
@@ -128,6 +149,58 @@ class ReservationControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("COMMON_INVALID_INPUT"))
 			.andExpect(jsonPath("$.error.message").value("must be greater than 0"));
+	}
+
+	private String seatStatus(Long seatId) {
+		return jdbcTemplate.queryForObject(
+			"SELECT status FROM seat WHERE id = ?",
+			String.class,
+			seatId
+		);
+	}
+
+	private int reservationCount(Long seatId) {
+		Integer count = jdbcTemplate.queryForObject(
+			"SELECT COUNT(*) FROM reservation WHERE seat_id = ?",
+			Integer.class,
+			seatId
+		);
+		return count == null ? 0 : count;
+	}
+
+	private int paymentCount(Long seatId) {
+		Integer count = jdbcTemplate.queryForObject(
+			"""
+			SELECT COUNT(*)
+			FROM payment p
+			JOIN reservation r ON p.reservation_id = r.id
+			WHERE r.seat_id = ?
+			""",
+			Integer.class,
+			seatId
+		);
+		return count == null ? 0 : count;
+	}
+
+	private String reservationStatus(Long seatId) {
+		return jdbcTemplate.queryForObject(
+			"SELECT status FROM reservation WHERE seat_id = ?",
+			String.class,
+			seatId
+		);
+	}
+
+	private String paymentStatus(Long seatId) {
+		return jdbcTemplate.queryForObject(
+			"""
+			SELECT p.status
+			FROM payment p
+			JOIN reservation r ON p.reservation_id = r.id
+			WHERE r.seat_id = ?
+			""",
+			String.class,
+			seatId
+		);
 	}
 
 }

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
@@ -15,6 +15,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
@@ -31,6 +32,9 @@ class SeatControllerTest {
 	@Autowired
 	private MockMvc mockMvc;
 
+	@Autowired
+	private JdbcTemplate jdbcTemplate;
+
 	@Test
 	@DisplayName("AVAILABLE 상태의 좌석을 HELD 상태로 점유할 수 있다")
 	void available_좌석_점유_성공() throws Exception{
@@ -39,6 +43,8 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.seatId").value(1))
 			.andExpect(jsonPath("$.data.status").value("HELD"));
+
+		assertEquals("HELD", seatStatus(1L));
 	}
 
 	@Test
@@ -49,6 +55,8 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_HELD"))
 			.andExpect(jsonPath("$.error.message").value("점유할 수 없는 좌석입니다."));
+
+		assertEquals("HELD", seatStatus(2L));
 	}
 
 	@Test
@@ -59,6 +67,8 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_HELD"))
 			.andExpect(jsonPath("$.error.message").value("점유할 수 없는 좌석입니다."));
+
+		assertEquals("CONFIRMED", seatStatus(3L));
 	}
 
 	@Test
@@ -69,6 +79,8 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_HELD"))
 			.andExpect(jsonPath("$.error.message").value("점유할 수 없는 좌석입니다."));
+
+		assertEquals("CANCELLED", seatStatus(4L));
 	}
 
 	@Test
@@ -145,6 +157,8 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(true))
 			.andExpect(jsonPath("$.data.seatId").value(2))
 			.andExpect(jsonPath("$.data.status").value("AVAILABLE"));
+
+		assertEquals("AVAILABLE", seatStatus(2L));
 	}
 
 	@Test
@@ -155,6 +169,8 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_RELEASED"))
 			.andExpect(jsonPath("$.error.message").value("해제할 수 없는 좌석입니다."));
+
+		assertEquals("AVAILABLE", seatStatus(1L));
 	}
 
 	@Test
@@ -165,6 +181,8 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_RELEASED"))
 			.andExpect(jsonPath("$.error.message").value("해제할 수 없는 좌석입니다."));
+
+		assertEquals("CONFIRMED", seatStatus(3L));
 	}
 
 	@Test
@@ -175,6 +193,8 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_CANNOT_BE_RELEASED"))
 			.andExpect(jsonPath("$.error.message").value("해제할 수 없는 좌석입니다."));
+
+		assertEquals("CANCELLED", seatStatus(4L));
 	}
 
 	@Test
@@ -185,6 +205,14 @@ class SeatControllerTest {
 			.andExpect(jsonPath("$.success").value(false))
 			.andExpect(jsonPath("$.error.code").value("SEAT_NOT_FOUND"))
 			.andExpect(jsonPath("$.error.message").value("좌석을 찾을 수 없습니다."));
+	}
+
+	private String seatStatus(Long seatId) {
+		return jdbcTemplate.queryForObject(
+			"SELECT status FROM seat WHERE id = ?",
+			String.class,
+			seatId
+		);
 	}
 
 }


### PR DESCRIPTION
## 작업 내용
- 예매 확정 API 테스트에 DB 상태 검증 추가
- HELD 좌석 예매 성공 후 seat, reservation, payment 상태 검증 추가
- AVAILABLE, CONFIRMED 상태 좌석 예매 실패 시 rollback 검증 추가
- 좌석 해제 API 테스트에 좌석 상태 검증 추가

## 확인한 것
- HELD 좌석 예매 성공 후 seat.status=CONFIRMED 반영 확인
- 예매 성공 시 reservation, payment row 생성 및 상태 반영 확인
- AVAILABLE, CONFIRMED 상태 좌석 예매 실패 시 reservation, payment 미생성 확인
- 좌석 해제 성공/실패 시 좌석 상태 유지 및 변경 확인
- ./gradlew test 전체 통과 확인

## 테스트
- ./gradlew test

Close #44 