### PR TITLE
읽기/쓰기 분리 DataSource 라우팅 적용

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
@@ -3,6 +3,7 @@ package com.ticketrush.centralserver.application.performance;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.PerformanceQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow;
@@ -14,6 +15,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class PerformanceQueryService {
 
 	private final PerformanceQueryMapper performanceQueryMapper;

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/schedule/ScheduleQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/schedule/ScheduleQueryService.java
@@ -3,6 +3,7 @@ package com.ticketrush.centralserver.application.schedule;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.ScheduleQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.model.ScheduleRow;
@@ -12,6 +13,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class ScheduleQueryService {
 
 	private final ScheduleQueryMapper scheduleQueryMapper;

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatQueryService.java
@@ -3,6 +3,7 @@ package com.ticketrush.centralserver.application.seat;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketrush.centralserver.domain.seat.SeatStatus;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
@@ -15,6 +16,7 @@ import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class SeatQueryService {
 
 	private final SeatQueryMapper seatQueryMapper;

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/DataSourceConfig.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/DataSourceConfig.java
@@ -1,11 +1,15 @@
 package com.ticketrush.centralserver.infrastructure.config.datasource;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import javax.sql.DataSource;
 
 import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
 
 @Configuration
 public class DataSourceConfig {
@@ -49,5 +53,20 @@ public class DataSourceConfig {
 			.build();
 	}
 
+	@Bean
+	@Primary
+	public DataSource routingDataSource() {
+		RoutingDataSource routingDataSource = new RoutingDataSource();
+
+		Map<Object, Object> targetDataSources = new HashMap<>();
+
+		targetDataSources.put(DataSourceType.MASTER, masterDataSource());
+		targetDataSources.put(DataSourceType.SLAVE, slave1DataSource());
+
+		routingDataSource.setTargetDataSources(targetDataSources);
+		routingDataSource.setDefaultTargetDataSource(masterDataSource());
+
+		return routingDataSource;
+	}
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/DataSourceConfig.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/DataSourceConfig.java
@@ -1,0 +1,53 @@
+package com.ticketrush.centralserver.infrastructure.config.datasource;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.autoconfigure.jdbc.DataSourceProperties;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class DataSourceConfig {
+
+	@Bean
+	@ConfigurationProperties(prefix = "app.datasource.master")
+	public DataSourceProperties masterDataSourceProperties() {
+		return new DataSourceProperties();
+	}
+
+	@Bean
+	public DataSource masterDataSource() {
+		return masterDataSourceProperties()
+			.initializeDataSourceBuilder()
+			.build();
+	}
+
+	@Bean
+	@ConfigurationProperties(prefix = "app.datasource.slave1")
+	public DataSourceProperties slave1DataSourceProperties() {
+		return new DataSourceProperties();
+	}
+
+	@Bean
+	public DataSource slave1DataSource() {
+		return slave1DataSourceProperties()
+			.initializeDataSourceBuilder()
+			.build();
+	}
+
+	@Bean
+	@ConfigurationProperties(prefix = "app.datasource.slave2")
+	public DataSourceProperties slave2DataSourceProperties() {
+		return new DataSourceProperties();
+	}
+
+	@Bean
+	public DataSource slave2DataSource() {
+		return slave2DataSourceProperties()
+			.initializeDataSourceBuilder()
+			.build();
+	}
+
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/DataSourceType.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/DataSourceType.java
@@ -1,0 +1,8 @@
+package com.ticketrush.centralserver.infrastructure.config.datasource;
+
+public enum DataSourceType {
+
+	MASTER,
+	SLAVE
+	;
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSource.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSource.java
@@ -1,0 +1,19 @@
+package com.ticketrush.centralserver.infrastructure.config.datasource;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class RoutingDataSource extends AbstractRoutingDataSource {
+
+	@Override
+	protected Object determineCurrentLookupKey() {
+		boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+		if (readOnly) {
+			return DataSourceType.SLAVE;
+		}
+
+		return DataSourceType.MASTER;
+	}
+
+}

--- a/central-server/src/main/resources/application-local.yml
+++ b/central-server/src/main/resources/application-local.yml
@@ -1,10 +1,25 @@
 spring:
   jackson:
     time-zone: Asia/Seoul
+
+app:
   datasource:
-    url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:13306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
-    username: ${DB_USERNAME:root}
-    password: ${DB_PASSWORD:rootpassword}
+      master:
+        url: jdbc:mysql://${DB_HOST:mysql-master}:${DB_PORT:3306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+        username: ${DB_USERNAME:root}
+        password: ${DB_PASSWORD:rootpassword}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+      slave1:
+        url: jdbc:mysql://${DB_SLAVE1_HOST:mysql-slave1}:${DB_PORT:3306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+        username: ${DB_USERNAME:root}
+        password: ${DB_PASSWORD:rootpassword}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+      slave2:
+        url: jdbc:mysql://${DB_SLAVE2_HOST:mysql-slave2}:${DB_PORT:3306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+        username: ${DB_USERNAME:root}
+        password: ${DB_PASSWORD:rootpassword}
+        driver-class-name: com.mysql.cj.jdbc.Driver
+
 
 server:
   port: ${SERVER_PORT:18080}

--- a/central-server/src/test/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSourceTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSourceTest.java
@@ -1,0 +1,51 @@
+package com.ticketrush.centralserver.infrastructure.config.datasource;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+class RoutingDataSourceTest {
+
+	private static class TestRoutingDataSource extends RoutingDataSource {
+		public Object currentLookupKey() {
+			return determineCurrentLookupKey();
+		}
+	}
+
+	@AfterEach
+	void tearDown() {
+		TransactionSynchronizationManager.clear();
+	}
+
+	@Test
+	@DisplayName("readOnly 트랜잭션이면 slave를 선택한다")
+	void readOnly_트랜잭션_slave() {
+
+		TestRoutingDataSource routingDataSource = new TestRoutingDataSource();
+
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		TransactionSynchronizationManager.setCurrentTransactionReadOnly(true);
+
+		Object lookupKey = routingDataSource.currentLookupKey();
+
+		assertEquals(DataSourceType.SLAVE, lookupKey);
+	}
+
+	@Test
+	@DisplayName("일반 트랜잭션이면 master를 선택한다")
+	void 일반_트랜잭션_master() {
+
+		TestRoutingDataSource routingDataSource = new TestRoutingDataSource();
+
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		TransactionSynchronizationManager.setCurrentTransactionReadOnly(false);
+
+		Object lookupKey = routingDataSource.currentLookupKey();
+
+		assertEquals(DataSourceType.MASTER, lookupKey);
+	}
+
+}

--- a/central-server/src/test/resources/application-test.yml
+++ b/central-server/src/test/resources/application-test.yml
@@ -5,3 +5,22 @@ spring:
     url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:13306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:rootpassword}
+    driver-class-name: com.mysql.cj.jdbc.Driver
+
+app:
+  datasource:
+    master:
+      url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:13306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      username: ${DB_USERNAME:root}
+      password: ${DB_PASSWORD:rootpassword}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+    slave1:
+      url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:13306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      username: ${DB_USERNAME:root}
+      password: ${DB_PASSWORD:rootpassword}
+      driver-class-name: com.mysql.cj.jdbc.Driver
+    slave2:
+      url: jdbc:mysql://${DB_HOST:localhost}:${DB_PORT:13306}/${DB_NAME:ticket}?serverTimezone=Asia/Seoul&characterEncoding=UTF-8
+      username: ${DB_USERNAME:root}
+      password: ${DB_PASSWORD:rootpassword}
+      driver-class-name: com.mysql.cj.jdbc.Driver


### PR DESCRIPTION
## 작업 내용
- master/slave datasource 설정 추가
- `RoutingDataSource`와 `DataSourceType` 기반 라우팅 구조 추가
- `readOnly` 트랜잭션 기준으로 master/slave를 선택하도록 적용
- 조회 서비스에 `@Transactional(readOnly = true)` 적용
- datasource 라우팅 테스트 추가

## 확인한 것
- master, slave1, slave2용 DataSource Bean 구성 확인
- 일반 트랜잭션에서 `MASTER`를 선택하는 라우팅 규칙 확인
- `readOnly` 트랜잭션에서 `SLAVE`를 선택하는 라우팅 규칙 확인
- 조회 서비스가 `readOnly` 트랜잭션으로 동작하도록 반영 확인
- `./gradlew test` 전체 통과 확인

## 테스트
- `./gradlew test`

Close #48 