### PR TITLE
복제 지연 대응 기준과 master read 예외 라우팅 적용

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatQueryService.java
@@ -6,6 +6,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketrush.centralserver.domain.seat.SeatStatus;
+import com.ticketrush.centralserver.infrastructure.config.datasource.RoutingDataSourceContext;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
 import com.ticketrush.centralserver.interfaces.api.schedule.dto.SeatResponse;
@@ -30,6 +31,16 @@ public class SeatQueryService {
 		return seatQueryMapper.findByScheduleIdAndStatus(scheduleId, status).stream()
 			.map(this::toResponse)
 			.toList();
+	}
+
+	public List<SeatResponse> getLatestSeats(Long scheduleId, String status) {
+		RoutingDataSourceContext.forceMaster();
+
+		try {
+			return getSeats(scheduleId, status);
+		} finally {
+			RoutingDataSourceContext.clear();
+		}
 	}
 
 	private SeatResponse toResponse(SeatRow row) {

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSource.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSource.java
@@ -7,6 +7,11 @@ public class RoutingDataSource extends AbstractRoutingDataSource {
 
 	@Override
 	protected Object determineCurrentLookupKey() {
+
+		if (RoutingDataSourceContext.isForceMaster()) {
+			return DataSourceType.MASTER;
+		}
+
 		boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
 
 		if (readOnly) {

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSourceContext.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSourceContext.java
@@ -1,0 +1,21 @@
+package com.ticketrush.centralserver.infrastructure.config.datasource;
+
+public class RoutingDataSourceContext {
+
+	private static final ThreadLocal<Boolean> FORCE_MASTER = ThreadLocal.withInitial(() -> false);
+
+	private RoutingDataSourceContext() {
+	}
+
+	public static void forceMaster() {
+		FORCE_MASTER.set(true);
+	}
+
+	public static boolean isForceMaster() {
+		return FORCE_MASTER.get();
+	}
+
+	public static void clear() {
+		FORCE_MASTER.remove();
+	}
+}

--- a/central-server/src/test/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSourceTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/infrastructure/config/datasource/RoutingDataSourceTest.java
@@ -18,6 +18,7 @@ class RoutingDataSourceTest {
 	@AfterEach
 	void tearDown() {
 		TransactionSynchronizationManager.clear();
+		RoutingDataSourceContext.clear();
 	}
 
 	@Test
@@ -48,4 +49,31 @@ class RoutingDataSourceTest {
 		assertEquals(DataSourceType.MASTER, lookupKey);
 	}
 
+	@Test
+	@DisplayName("master 강제 설정이 있으면 readOnly 트랜잭션도 master를 선택한다")
+	void master_강제_설정_readOnly_트랜잭션_master_선택() {
+		TestRoutingDataSource routingDataSource = new TestRoutingDataSource();
+
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		TransactionSynchronizationManager.setCurrentTransactionReadOnly(true);
+		RoutingDataSourceContext.forceMaster();
+
+		Object lookupKey = routingDataSource.currentLookupKey();
+		assertEquals(DataSourceType.MASTER, lookupKey);
+	}
+
+	@Test
+	@DisplayName("master 강제 설정을 해제하면 다시 기본 라우팅 규칙을 따른다")
+	void master_강제_설정_해제_다시_기본_라우팅_규칙() {
+		TestRoutingDataSource routingDataSource = new TestRoutingDataSource();
+
+		TransactionSynchronizationManager.setActualTransactionActive(true);
+		TransactionSynchronizationManager.setCurrentTransactionReadOnly(true);
+		RoutingDataSourceContext.forceMaster();
+		RoutingDataSourceContext.clear();
+
+		Object lookupKey = routingDataSource.currentLookupKey();
+
+		assertEquals(DataSourceType.SLAVE, lookupKey);
+	}
 }


### PR DESCRIPTION
## 작업 내용
- `RoutingDataSourceContext` 추가
- `force master` 설정 시 `readOnly` 트랜잭션보다 우선해 master를 선택하도록 라우팅 확장
- 최신 좌석 상태 조회를 위한 `SeatQueryService.getLatestSeats` 추가
- master 강제 라우팅과 기본 라우팅 복귀 동작 테스트 추가
- 테스트용 datasource 설정 정합성 보강

## 확인한 것
- 기본 `readOnly` 트랜잭션은 `SLAVE`를 선택하는 라우팅 규칙 확인
- 일반 트랜잭션은 `MASTER`를 선택하는 라우팅 규칙 확인
- `force master` 설정 시 `readOnly` 트랜잭션도 `MASTER`를 선택하는 것 확인
- `clear()` 이후 다시 기본 라우팅 규칙으로 복귀하는 것 확인
- `@MybatisTest`, `@SpringBootTest` 환경 모두에서 datasource 설정이 정상 동작하는 것 확인
- `./gradlew test` 전체 통과 확인

## 테스트
- `./gradlew test`

Close #50 