### PR TITLE
인기 공연 Redis 캐시 1차 적용

### DIFF
--- a/central-server/build.gradle
+++ b/central-server/build.gradle
@@ -34,6 +34,9 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testCompileOnly 'org.projectlombok:lombok'
 	testAnnotationProcessor 'org.projectlombok:lombok'
+
+	// Redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 }
 
 tasks.named('test') {

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
@@ -17,7 +17,9 @@ import com.ticketrush.centralserver.support.exception.ApiException;
 import com.ticketrush.centralserver.support.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 @Transactional(readOnly = true)
@@ -36,8 +38,11 @@ public class PerformanceQueryService {
 		Optional<String> cached = performanceCacheRepository.getPerformanceList(PERFORMANCE_LIST_KEY);
 
 		if (cached.isPresent()) {
+			log.info("공연 목록 캐시 hit - key={}", PERFORMANCE_LIST_KEY);
 			return deserializePerformanceList(cached.get());
 		}
+
+		log.info("공연 목록 캐시 miss - key={}", PERFORMANCE_LIST_KEY);
 
 		List<PerformanceResponse> responses = performanceQueryMapper.findAll().stream()
 			.map(this::toResponse)
@@ -45,6 +50,8 @@ public class PerformanceQueryService {
 
 		String json = serializePerformanceList(responses);
 		performanceCacheRepository.setPerformanceList(PERFORMANCE_LIST_KEY, json, PERFORMANCE_LIST_TTL);
+
+		log.info("공연 목록 캐시 저장 - key={}, ttl={}s", PERFORMANCE_LIST_KEY, PERFORMANCE_LIST_TTL.getSeconds());
 
 		return responses;
 	}

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/performance/PerformanceQueryService.java
@@ -1,10 +1,15 @@
 package com.ticketrush.centralserver.application.performance;
 
+import java.time.Duration;
 import java.util.List;
+import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticketrush.centralserver.infrastructure.cache.PerformanceCacheRepository;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.PerformanceQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow;
 import com.ticketrush.centralserver.interfaces.api.performance.dto.PerformanceResponse;
@@ -18,12 +23,30 @@ import lombok.RequiredArgsConstructor;
 @Transactional(readOnly = true)
 public class PerformanceQueryService {
 
+	private static final String PERFORMANCE_LIST_KEY = "performance:list:v1";
+	private static final Duration PERFORMANCE_LIST_TTL = Duration.ofSeconds(60);
+
+	private final ObjectMapper objectMapper;
+
+	private final PerformanceCacheRepository performanceCacheRepository;
 	private final PerformanceQueryMapper performanceQueryMapper;
 
 	public List<PerformanceResponse> getPerformances() {
-		return performanceQueryMapper.findAll().stream()
+
+		Optional<String> cached = performanceCacheRepository.getPerformanceList(PERFORMANCE_LIST_KEY);
+
+		if (cached.isPresent()) {
+			return deserializePerformanceList(cached.get());
+		}
+
+		List<PerformanceResponse> responses = performanceQueryMapper.findAll().stream()
 			.map(this::toResponse)
 			.toList();
+
+		String json = serializePerformanceList(responses);
+		performanceCacheRepository.setPerformanceList(PERFORMANCE_LIST_KEY, json, PERFORMANCE_LIST_TTL);
+
+		return responses;
 	}
 
 	public PerformanceResponse getPerformance(Long performanceId) {
@@ -41,6 +64,23 @@ public class PerformanceQueryService {
 		);
 	}
 
+	private String serializePerformanceList(List<PerformanceResponse> responses) {
+		try {
+			return objectMapper.writeValueAsString(responses);
+		} catch (Exception e) {
+			throw new IllegalStateException("공연 목록 캐시 직렬화에 실패했습니다.", e);
+		}
+	}
 
+	private List<PerformanceResponse> deserializePerformanceList(String json) {
+		try {
+			return objectMapper.readValue(
+				json,
+				new TypeReference<List<PerformanceResponse>>() {}
+			);
+		} catch (Exception e) {
+			throw new IllegalStateException("공연 목록 캐시 역직렬화에 실패했습니다.", e);
+		}
+	}
 
 }

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/cache/PerformanceCacheRepository.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/cache/PerformanceCacheRepository.java
@@ -1,0 +1,25 @@
+package com.ticketrush.centralserver.infrastructure.cache;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class PerformanceCacheRepository {
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public Optional<String> getPerformanceList(String key){
+		return Optional.ofNullable(redisTemplate.opsForValue().get(key));
+	}
+
+	public void setPerformanceList(String key, String value, Duration ttl){
+		redisTemplate.opsForValue().set(key, value, ttl);
+	}
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/redis/RedisConfig.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/config/redis/RedisConfig.java
@@ -1,0 +1,26 @@
+package com.ticketrush.centralserver.infrastructure.config.redis;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplate(RedisConnectionFactory redisConnectionFactory) {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory);
+
+		StringRedisSerializer stringRedisSerializer = new StringRedisSerializer();
+
+		redisTemplate.setKeySerializer(stringRedisSerializer);
+		redisTemplate.setValueSerializer(stringRedisSerializer);
+		redisTemplate.setHashKeySerializer(stringRedisSerializer);
+		redisTemplate.setHashValueSerializer(stringRedisSerializer);
+		return redisTemplate;
+	}
+
+}

--- a/central-server/src/main/resources/application-local.yml
+++ b/central-server/src/main/resources/application-local.yml
@@ -2,6 +2,11 @@ spring:
   jackson:
     time-zone: Asia/Seoul
 
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+
 app:
   datasource:
       master:

--- a/central-server/src/test/java/com/ticketrush/centralserver/application/performance/PerformanceQueryServiceTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/application/performance/PerformanceQueryServiceTest.java
@@ -1,0 +1,127 @@
+package com.ticketrush.centralserver.application.performance;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.ticketrush.centralserver.infrastructure.cache.PerformanceCacheRepository;
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.PerformanceQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.model.PerformanceRow;
+import com.ticketrush.centralserver.interfaces.api.performance.dto.PerformanceResponse;
+
+@ExtendWith(MockitoExtension.class)
+class PerformanceQueryServiceTest {
+
+	private static final String PERFORMANCE_LIST_KEY = "performance:list:v1";
+
+	@Mock
+	private PerformanceCacheRepository performanceCacheRepository;
+
+	@Mock
+	private PerformanceQueryMapper performanceQueryMapper;
+
+	private ObjectMapper objectMapper = new ObjectMapper();
+
+	private PerformanceQueryService performanceQueryService;
+
+	@BeforeEach
+	void setUp() {
+		performanceQueryService = new PerformanceQueryService(
+			objectMapper,
+			performanceCacheRepository,
+			performanceQueryMapper
+		);
+	}
+
+	@Test
+	@DisplayName("캐시 미스 시 DB에서 공연 목록을 조회하고 캐시에 저장한다")
+	void 캐시_미스_시_DB_조회_후_캐시에_저장한다() {
+		List<PerformanceRow> rows = List.of(
+			new PerformanceRow(1L, "공연 A", "올림픽홀", 500),
+			new PerformanceRow(2L, "공연 B", "세종문화회관", 300)
+		);
+
+		when(performanceCacheRepository.getPerformanceList(PERFORMANCE_LIST_KEY))
+			.thenReturn(Optional.empty());
+		when(performanceQueryMapper.findAll())
+			.thenReturn(rows);
+
+		List<PerformanceResponse> result = performanceQueryService.getPerformances();
+
+		assertEquals(2, result.size());
+		assertEquals(1L, result.get(0).id());
+		assertEquals("공연 A", result.get(0).title());
+		assertEquals("올림픽홀", result.get(0).venue());
+		assertEquals(500, result.get(0).totalSeats());
+
+		assertEquals(2L, result.get(1).id());
+		assertEquals("공연 B", result.get(1).title());
+		assertEquals("세종문화회관", result.get(1).venue());
+		assertEquals(300, result.get(1).totalSeats());
+
+		verify(performanceCacheRepository, times(1))
+			.getPerformanceList(PERFORMANCE_LIST_KEY);
+		verify(performanceQueryMapper, times(1))
+			.findAll();
+		verify(performanceCacheRepository, times(1))
+			.setPerformanceList(eq(PERFORMANCE_LIST_KEY), any(String.class), eq(Duration.ofSeconds(60)));
+
+	}
+
+	@Test
+	@DisplayName("캐시 히트 시 Redis 값을 반환하고 DB를 조회하지 않는다")
+	void 캐시_히트_시_캐시값을_반환하고_DB를_조회하지_않는다() {
+
+		String cachedJson = """
+		[
+		  {
+			"id": 1,
+			"title": "공연 A",
+			"venue": "올림픽홀",
+			"totalSeats": 500
+		  },
+		  {
+			"id": 2,
+			"title": "공연 B",
+			"venue": "세종문화회관",
+			"totalSeats": 300
+		  }
+		]
+		""";
+
+		when(performanceCacheRepository.getPerformanceList(PERFORMANCE_LIST_KEY))
+			.thenReturn(Optional.of(cachedJson));
+
+		List<PerformanceResponse> result = performanceQueryService.getPerformances();
+
+		assertEquals(2, result.size());
+		assertEquals(1L, result.get(0).id());
+		assertEquals("공연 A", result.get(0).title());
+		assertEquals("올림픽홀", result.get(0).venue());
+		assertEquals(500, result.get(0).totalSeats());
+
+		assertEquals(2L, result.get(1).id());
+		assertEquals("공연 B", result.get(1).title());
+		assertEquals("세종문화회관", result.get(1).venue());
+		assertEquals(300, result.get(1).totalSeats());
+
+		verify(performanceCacheRepository, times(1))
+			.getPerformanceList(PERFORMANCE_LIST_KEY);
+		verify(performanceQueryMapper, times(0))
+			.findAll();
+		verify(performanceCacheRepository, times(0))
+			.setPerformanceList(eq(PERFORMANCE_LIST_KEY), any(String.class), eq(Duration.ofSeconds(60)));
+	}
+
+}

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/performance/PerformanceControllerTest.java
@@ -1,16 +1,23 @@
 package com.ticketrush.centralserver.interfaces.api.performance;
 
+import static org.mockito.Mockito.*;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.ticketrush.centralserver.infrastructure.cache.PerformanceCacheRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -23,6 +30,15 @@ class PerformanceControllerTest {
 
 	@Autowired
 	private MockMvc mockMvc;
+
+	@MockitoBean
+	private PerformanceCacheRepository performanceCacheRepository;
+
+	@BeforeEach
+	void setUp() {
+		when(performanceCacheRepository.getPerformanceList("performance:list:v1"))
+			.thenReturn(Optional.empty());
+	}
 
 	@Test
 	@DisplayName("공연 목록 조회 API가 정상 응답한다")

--- a/central-server/src/test/resources/application-test.yml
+++ b/central-server/src/test/resources/application-test.yml
@@ -6,6 +6,10 @@ spring:
     username: ${DB_USERNAME:root}
     password: ${DB_PASSWORD:rootpassword}
     driver-class-name: com.mysql.cj.jdbc.Driver
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
 
 app:
   datasource:


### PR DESCRIPTION
## 작업 내용
- Redis 의존성 및 연결 설정 추가
- 공연 목록 조회 캐시 저장소 추가
- 공연 목록 조회에 cache aside 방식 적용
- 캐시 key와 TTL 정책 적용
- 캐시 미스/히트 동작 테스트 추가
- 공연 목록 조회 API 테스트에서 캐시 저장소 mock 처리
- 캐시 hit/miss 로그 추가

## 확인한 것
- 캐시 미스 시 DB 조회 후 Redis 저장 흐름 확인
- 캐시 히트 시 Redis 값 반환과 DB 미조회 흐름 확인
- 공연 목록 조회 API가 캐시 적용 이후에도 정상 응답하는지 확인
- 캐시 hit/miss와 저장 시점을 로그로 확인할 수 있도록 구성
- `./gradlew test` 통과 확인

## 테스트
- `./gradlew test`

Close #52 