### PR TITLE
좌석 홀드 TTL Redis 연동

### DIFF
--- a/central-server/src/main/java/com/ticketrush/centralserver/CentralServerApplication.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/CentralServerApplication.java
@@ -2,7 +2,9 @@ package com.ticketrush.centralserver;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class CentralServerApplication {
 

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/reservation/ReservationConfirmService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/reservation/ReservationConfirmService.java
@@ -15,7 +15,9 @@ import com.ticketrush.centralserver.support.exception.ApiException;
 import com.ticketrush.centralserver.support.exception.ErrorCode;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @Service
 public class ReservationConfirmService {
@@ -60,7 +62,11 @@ public class ReservationConfirmService {
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 
-		seatHoldCacheRepository.deleteHold(seat.id());
+		try {
+			seatHoldCacheRepository.deleteHold(seat.id());
+		} catch (Exception e) {
+			log.warn("Redis hold key 삭제 실패. seatId={}", seat.id(), e);
+		}
 
 		return new ReservationConfirmResponse(
 			reservationId,

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/reservation/ReservationConfirmService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/reservation/ReservationConfirmService.java
@@ -5,6 +5,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketrush.centralserver.application.payment.PaymentCreateCommand;
 import com.ticketrush.centralserver.domain.seat.SeatStatus;
+import com.ticketrush.centralserver.infrastructure.cache.SeatHoldCacheRepository;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.PaymentQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.ReservationQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
@@ -25,6 +26,7 @@ public class ReservationConfirmService {
 	private final SeatQueryMapper seatQueryMapper;
 	private final ReservationQueryMapper reservationQueryMapper;
 	private final PaymentQueryMapper paymentQueryMapper;
+	private final SeatHoldCacheRepository seatHoldCacheRepository;
 
 	@Transactional
 	public ReservationConfirmResponse confirmReservation(ReservationConfirmCommand command) {
@@ -57,6 +59,8 @@ public class ReservationConfirmService {
 		if (confirmCount != 1) {
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
+
+		seatHoldCacheRepository.deleteHold(seat.id());
 
 		return new ReservationConfirmResponse(
 			reservationId,

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatHoldExpireScheduler.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatHoldExpireScheduler.java
@@ -1,0 +1,29 @@
+package com.ticketrush.centralserver.application.seat;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class SeatHoldExpireScheduler {
+
+	private static final Duration SEAT_HOLD_TTL = Duration.ofMinutes(5);
+
+	private final SeatReleaseService seatReleaseService;
+
+	/*
+	Redis TTL 자체를 직접 구독하지 않고,
+    DB held_at 기준으로 만료된 HELD 좌석을 주기적으로 복구한다.
+	 */
+	@Scheduled(fixedDelay = 60000)
+	public void releaseExpiredSeatHolds() {
+		LocalDateTime threshold = LocalDateTime.now().minus(SEAT_HOLD_TTL);
+		seatReleaseService.releaseExpiredSeats(threshold);
+	}
+
+}

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatHoldService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatHoldService.java
@@ -1,9 +1,12 @@
 package com.ticketrush.centralserver.application.seat;
 
+import java.time.Duration;
+
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketrush.centralserver.domain.seat.SeatStatus;
+import com.ticketrush.centralserver.infrastructure.cache.SeatHoldCacheRepository;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
 import com.ticketrush.centralserver.interfaces.api.seat.dto.SeatHoldResponse;
 import com.ticketrush.centralserver.support.exception.ApiException;
@@ -15,7 +18,10 @@ import lombok.RequiredArgsConstructor;
 @Service
 public class SeatHoldService {
 
+	private static final Duration SEAT_HOLD_TTL = Duration.ofMinutes(5);
+
 	private final SeatQueryMapper seatQueryMapper;
+	private final SeatHoldCacheRepository seatHoldCacheRepository;
 
 	@Transactional
 	public SeatHoldResponse holdSeat(Long seatId) {
@@ -23,6 +29,9 @@ public class SeatHoldService {
 		int updatedCount = seatQueryMapper.holdSeatIfAvailable(seatId);
 
 		if (updatedCount == 1) {
+
+			seatHoldCacheRepository.saveHold(seatId, SEAT_HOLD_TTL);
+
 			return new SeatHoldResponse(seatId, SeatStatus.HELD.name());
 		}
 

--- a/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseService.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/application/seat/SeatReleaseService.java
@@ -7,6 +7,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.ticketrush.centralserver.domain.seat.SeatStatus;
+import com.ticketrush.centralserver.infrastructure.cache.SeatHoldCacheRepository;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
 import com.ticketrush.centralserver.interfaces.api.seat.dto.SeatReleaseResponse;
@@ -22,6 +23,7 @@ public class SeatReleaseService {
 	private static final String AVAILABLE = "AVAILABLE";
 
 	private final SeatQueryMapper seatQueryMapper;
+	private final SeatHoldCacheRepository seatHoldCacheRepository;
 
 	@Transactional
 	public SeatReleaseResponse releaseSeat(SeatReleaseCommand command) {
@@ -43,6 +45,8 @@ public class SeatReleaseService {
 			throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 		}
 
+		seatHoldCacheRepository.deleteHold(seatId);
+
 		return new SeatReleaseResponse(seatId, AVAILABLE);
 	}
 
@@ -58,6 +62,8 @@ public class SeatReleaseService {
 			if (releaseCount != 1) {
 				throw new ApiException(ErrorCode.INTERNAL_SERVER_ERROR);
 			}
+
+			seatHoldCacheRepository.deleteHold(seat.id());
 
 			totalReleaseCount += releaseCount;
 		}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/cache/SeatHoldCacheRepository.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/cache/SeatHoldCacheRepository.java
@@ -19,6 +19,10 @@ public class SeatHoldCacheRepository {
 		redisTemplate.opsForValue().set(key(seatId), "HELD", ttl);
 	}
 
+	public void deleteHold(Long seatId) {
+		redisTemplate.delete(key(seatId));
+	}
+
 	private String key(Long seatId) {
 		return SEAT_HOLD_KEY_PREFIX + seatId;
 	}

--- a/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/cache/SeatHoldCacheRepository.java
+++ b/central-server/src/main/java/com/ticketrush/centralserver/infrastructure/cache/SeatHoldCacheRepository.java
@@ -1,0 +1,26 @@
+package com.ticketrush.centralserver.infrastructure.cache;
+
+import java.time.Duration;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Repository
+public class SeatHoldCacheRepository {
+
+	private static final String SEAT_HOLD_KEY_PREFIX = "seat:hold:";
+
+	private final RedisTemplate<String, String> redisTemplate;
+
+	public void saveHold(Long seatId, Duration ttl) {
+		redisTemplate.opsForValue().set(key(seatId), "HELD", ttl);
+	}
+
+	private String key(Long seatId) {
+		return SEAT_HOLD_KEY_PREFIX + seatId;
+	}
+
+}

--- a/central-server/src/test/java/com/ticketrush/centralserver/application/reservation/ReservationConfirmServiceTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/application/reservation/ReservationConfirmServiceTest.java
@@ -1,0 +1,117 @@
+package com.ticketrush.centralserver.application.reservation;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ticketrush.centralserver.infrastructure.cache.SeatHoldCacheRepository;
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.PaymentQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.ReservationQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
+import com.ticketrush.centralserver.interfaces.api.reservation.dto.ReservationConfirmResponse;
+import com.ticketrush.centralserver.support.exception.ApiException;
+import com.ticketrush.centralserver.support.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationConfirmServiceTest {
+
+	@Mock
+	private SeatQueryMapper seatQueryMapper;
+
+	@Mock
+	private ReservationQueryMapper reservationQueryMapper;
+
+	@Mock
+	private PaymentQueryMapper paymentQueryMapper;
+
+	@Mock
+	private SeatHoldCacheRepository seatHoldCacheRepository;
+
+	private ReservationConfirmService reservationConfirmService;
+
+	@BeforeEach
+	void setUp() {
+		reservationConfirmService = new ReservationConfirmService(
+			seatQueryMapper,
+			reservationQueryMapper,
+			paymentQueryMapper,
+			seatHoldCacheRepository
+		);
+	}
+
+	@Test
+	@DisplayName("예매 확정 성공 시 Redis hold key를 삭제한다")
+	void 예매_확정_성공_시_Redis_hold_key를_삭제한다() {
+
+		SeatRow heldSeat = new SeatRow(
+			1L,
+			1L,
+			"A1",
+			"HELD",
+			50000
+		);
+
+		ReservationConfirmCommand command = new ReservationConfirmCommand(100L, 1L);
+
+		when(seatQueryMapper.findByIdForUpdate(1L))
+			.thenReturn(Optional.of(heldSeat));
+
+		when(reservationQueryMapper.findIdBySeatId(1L))
+			.thenReturn(Optional.of(10L));
+
+		when(paymentQueryMapper.findIdByReservationId(10L))
+			.thenReturn(Optional.of(20L));
+
+		when(seatQueryMapper.confirmSeat(1L))
+			.thenReturn(1);
+
+		ReservationConfirmResponse response = reservationConfirmService.confirmReservation(command);
+
+		assertEquals(10L, response.reservationId());
+		assertEquals(20L, response.paymentId());
+		assertEquals(1L, response.seatId());
+		assertEquals(100L, response.userId());
+		assertEquals("CONFIRMED", response.reservationStatus());
+		assertEquals("PENDING", response.paymentStatus());
+		assertEquals(50000, response.amount());
+		verify(seatQueryMapper).confirmSeat(1L);
+		verify(seatHoldCacheRepository).deleteHold(1L);
+	}
+
+	@Test
+	@DisplayName("예매 확정 실패 시 Redis hold key를 삭제하지 않는다")
+	void 예매_확정_실패_시_Redis_hold_key를_삭제하지_않는다() {
+		SeatRow availableSeat = new SeatRow(
+			1L,
+			1L,
+			"A1",
+			"AVAILABLE",
+			50000
+		);
+
+		ReservationConfirmCommand command = new ReservationConfirmCommand(100L, 1L);
+
+		when(seatQueryMapper.findByIdForUpdate(1L))
+			.thenReturn(Optional.of(availableSeat));
+
+		ApiException exception = assertThrows(
+			ApiException.class,
+			() -> reservationConfirmService.confirmReservation(command)
+		);
+
+		assertEquals(ErrorCode.SEAT_CANNOT_BE_CONFIRMED, exception.getErrorCode());
+		verify(seatHoldCacheRepository, never()).deleteHold(anyLong());
+		verify(reservationQueryMapper, never()).insertReservation(any());
+		verify(paymentQueryMapper, never()).insertPayment(any());
+		verify(seatQueryMapper, never()).confirmSeat(anyLong());
+	}
+}

--- a/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatHoldExpireSchedulerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatHoldExpireSchedulerTest.java
@@ -1,0 +1,50 @@
+package com.ticketrush.centralserver.application.seat;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class SeatHoldExpireSchedulerTest {
+
+	@Mock
+	private SeatReleaseService seatReleaseService;
+
+	private SeatHoldExpireScheduler seatHoldExpireScheduler;
+
+	@BeforeEach
+	void setUp() {
+		seatHoldExpireScheduler = new SeatHoldExpireScheduler(seatReleaseService);
+	}
+
+	@Test
+	@DisplayName("만료된 홀드 복구 스케줄이 5분 전 기준으로 복구를 요청한다")
+	void 만료된_홀드_복구_스케줄이_5분_전_기준으로_복구를_요청한다() {
+
+		LocalDateTime beforeCall = LocalDateTime.now();
+
+		seatHoldExpireScheduler.releaseExpiredSeatHolds();
+
+		LocalDateTime afterCall = LocalDateTime.now();
+
+		ArgumentCaptor<LocalDateTime> thresholdCaptor = ArgumentCaptor.forClass(LocalDateTime.class);
+		verify(seatReleaseService).releaseExpiredSeats(thresholdCaptor.capture());
+
+		LocalDateTime capturedThreshold = thresholdCaptor.getValue();
+
+		assertFalse(capturedThreshold.isBefore(beforeCall.minusMinutes(5)));
+		assertFalse(capturedThreshold.isAfter(afterCall.minusMinutes(5)));
+
+	}
+
+
+}

--- a/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatHoldServiceTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatHoldServiceTest.java
@@ -1,0 +1,73 @@
+package com.ticketrush.centralserver.application.seat;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.ticketrush.centralserver.infrastructure.cache.SeatHoldCacheRepository;
+import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
+import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
+import com.ticketrush.centralserver.support.exception.ApiException;
+import com.ticketrush.centralserver.support.exception.ErrorCode;
+
+@ExtendWith(MockitoExtension.class)
+class SeatHoldServiceTest {
+
+	private static final Duration SEAT_HOLD_TTL = Duration.ofMinutes(5);
+
+	@Mock
+	private SeatQueryMapper seatQueryMapper;
+
+	@Mock
+	private SeatHoldCacheRepository seatHoldCacheRepository;
+
+	private SeatHoldService seatHoldService;
+
+	@BeforeEach
+	void setUp() {
+		seatHoldService = new SeatHoldService(
+			seatQueryMapper,
+			seatHoldCacheRepository
+		);
+	}
+
+	@Test
+	@DisplayName("좌석 점유 성공 시 Redis 홀드 TTL을 저장한다")
+	void 좌석_점유_성공_시_Redis_홀드_TTL_저장() {
+
+		when(seatQueryMapper.holdSeatIfAvailable(1L))
+			.thenReturn(1);
+
+		seatHoldService.holdSeat(1L);
+
+		verify(seatHoldCacheRepository, times(1))
+			.saveHold(1L, SEAT_HOLD_TTL);
+	}
+
+	@Test
+	@DisplayName("좌석 점유 실패 시 Redis 홀드 TTL을 저장하지 않는다")
+	void 좌석_점유_실패_시_Redis_홀드_TTL_미저장() {
+
+		when(seatQueryMapper.holdSeatIfAvailable(1L))
+			.thenReturn(0);
+		when(seatQueryMapper.findById(1L))
+			.thenReturn(Optional.of(new SeatRow(1L, 1L, "A-1", "HELD", 10000)));
+
+		ApiException exception = assertThrows(ApiException.class,
+			() -> seatHoldService.holdSeat(1L));
+
+		assertEquals(ErrorCode.SEAT_CANNOT_BE_HELD, exception.getErrorCode());
+
+		verify(seatHoldCacheRepository, never())
+			.saveHold(anyLong(), any(Duration.class));
+	}
+}

--- a/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatReleaseServiceTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/application/seat/SeatReleaseServiceTest.java
@@ -1,6 +1,7 @@
 package com.ticketrush.centralserver.application.seat;
 
 import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
 
 import java.time.LocalDateTime;
 
@@ -9,8 +10,10 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 
+import com.ticketrush.centralserver.infrastructure.cache.SeatHoldCacheRepository;
 import com.ticketrush.centralserver.infrastructure.persistence.mapper.SeatQueryMapper;
 import com.ticketrush.centralserver.infrastructure.persistence.model.SeatRow;
 
@@ -28,6 +31,9 @@ class SeatReleaseServiceTest {
 	@Autowired
 	private SeatQueryMapper seatQueryMapper;
 
+	@MockitoBean
+	private SeatHoldCacheRepository seatHoldCacheRepository;
+
 
 	@Test
 	@DisplayName("만료된 좌석을 복구할 수 있다")
@@ -42,6 +48,9 @@ class SeatReleaseServiceTest {
 		assertEquals(1, releasedCount);
 		assertEquals("AVAILABLE", expiredSeat.status());
 		assertEquals("HELD", recentSeat.status());
+
+		verify(seatHoldCacheRepository, times(1))
+			.deleteHold(2L);
 	}
 
 	@Test
@@ -57,6 +66,8 @@ class SeatReleaseServiceTest {
 		assertEquals(0, releasedCount);
 		assertEquals("HELD", expiredCandidate.status());
 		assertEquals("HELD", recentSeat.status());
+		verify(seatHoldCacheRepository, never())
+			.deleteHold(anyLong());
 	}
 
 

--- a/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
+++ b/central-server/src/test/java/com/ticketrush/centralserver/interfaces/api/seat/SeatControllerTest.java
@@ -17,8 +17,11 @@ import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMock
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.web.servlet.MockMvc;
+
+import com.ticketrush.centralserver.infrastructure.cache.SeatHoldCacheRepository;
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -34,6 +37,9 @@ class SeatControllerTest {
 
 	@Autowired
 	private JdbcTemplate jdbcTemplate;
+
+	@MockitoBean
+	private SeatHoldCacheRepository seatHoldCacheRepository;
 
 	@Test
 	@DisplayName("AVAILABLE 상태의 좌석을 HELD 상태로 점유할 수 있다")


### PR DESCRIPTION
## 작업 내용
- 좌석 홀드 Redis key namespace 추가
- 좌석 점유 성공 시 Redis에 TTL key 저장 연결
- 스케줄러 기반 홀드 만료 복구 흐름 추가
- 좌석 해제 및 예매 확정 성공 시 Redis hold key 정리 연결
- 홀드 만료 스케줄 테스트 추가
- 좌석 해제/예매 확정 서비스 테스트에 Redis hold key 정리 검증 추가

## 확인한 것
- 좌석 점유 성공 시 seat:hold:{seatId} 형태의 Redis TTL key 저장 확인
- Redis TTL 자체를 직접 구독하지 않고, DB held_at 기준으로 만료된 HELD 좌석을 주기적으로 복구하도록 연결한 것 확인
- 좌석 해제 성공 시 Redis hold key 삭제 확인
- 예매 확정 성공 시 Redis hold key 삭제 확인
- 만료 복구 시 Redis hold key 삭제 확인
- `./gradlew test` 전체 통과 확인

## 테스트
- `./gradlew test`

Close #56 